### PR TITLE
update README with system component and flow details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,54 @@
+# Flashtestations
+
+A protocol for allowing any [TDX device](https://collective.flashbots.net/t/building-secure-ethereum-blocks-on-minimal-intel-tdx-confidential-vms/3795) to prove its output onchain
+
+Its first use case will be for proving that blocks on the Unichain L2 were built [using fair and transparent ordering rules](https://blog.uniswap.org/rollup-boost-is-live-on-unichain)
+
+
+## System Components
+
+1. TEE Devices
+1. TEE Public Keys (these are used to identify and verify TEEs and their outputs)
+1. TEE Attestations (also called Quotes)
+1. Block Signature Transaction
+1. Governance Values
+
+## System Flows
+
+1. Initialize Governance values
+    
+    a. Governance (e.g. UNI DAO) is the only address than can register and de-register TEE devices
+    
+    b. Governance is the only address that can wipe the Registry (this exists only as a nuclear option to protect against system compromise)
+1. Registering a TEE Device (also referred to as a block builder)
+    
+    a. Should only be callable by governance
+    
+    b. Verify TEE Quote
+    
+    c. extract and store TEE public key
+    
+    d. set liveness (we want a way to indicate that a TEE device has not been active for a long period of time, and for that we use liveness)
+    
+    e. Mark TEE device as "active"
+1. Verify Flashtestation transaction
+    
+    a. Check signature of transactions against registry of live builder keys
+    
+    b. update TEE device liveness
+1. Deregistering a TEE Device
+    
+    a. Should only be callable by governance
+    
+    b. Mark TEE device as "retired"
+
+## TODOs
+
+- [] Implement Governance-related values
+- [] Implement TEE Device Registry
+- [] Implement Flashtestation transaction verification
+- [] Implement TEE Device Deregistration
+
 ## Foundry
 
 **Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.**

--- a/src/TEERegistry.sol
+++ b/src/TEERegistry.sol
@@ -6,29 +6,29 @@ import "solmate/src/auth/Owned.sol";
 import "automata-dcap-attestation/contracts/interfaces/IPCCSRouter.sol";
 
 struct DCAPEvent {
-	uint32 Index;
-	uint32 EventType;
-	bytes EventPayload;
-	bytes32 Digest;
+    uint32 Index;
+    uint32 EventType;
+    bytes EventPayload;
+    bytes32 Digest;
 }
 
 struct DCAPReport {
     // All fields are expected to be 48 bytes
-	bytes mrTd;          // Measurement register for TD
-	bytes[4] RTMRs;      // Runtime measurement registers
-	bytes mrOwner;       // Measurement register for owner
-	bytes mrConfigId;    // Measurement register for config ID
-	bytes mrConfigOwner; // Measurement register for config owner
+    bytes mrTd; // Measurement register for TD
+    bytes[4] RTMRs; // Runtime measurement registers
+    bytes mrOwner; // Measurement register for owner
+    bytes mrConfigId; // Measurement register for config ID
+    bytes mrConfigOwner; // Measurement register for config owner
 }
 
 struct MAAReport {
-	bytes32[24] PCRs;
+    bytes32[24] PCRs;
 }
 
 struct AppPKI {
-	bytes ca;
-	bytes pubkey;
-	bytes attestation;
+    bytes ca;
+    bytes pubkey;
+    bytes attestation;
 }
 
 /**
@@ -42,10 +42,10 @@ contract TEERegistry is Owned, TransientReentrancyGuard {
 
     // State variables
     string[] public instanceDomainNames;
-	AppPKI public app_pki;
+    AppPKI public app_pki;
 
-	// Notes config and secrets locations
-	string[] public storageBackends;
+    // Notes config and secrets locations
+    string[] public storageBackends;
     // Maps config hash to config data and secrets for onchain DA
     mapping(bytes32 => bytes) public artifacts;
     // Maps identity to config hash
@@ -53,14 +53,14 @@ contract TEERegistry is Owned, TransientReentrancyGuard {
 
     // Events
     event InstanceDomainRegistered(string domain, address registrar);
-	event StorageBackendSet(string location, address setter);
-	event StorageBackendRemoved(string location, address remover);
+    event StorageBackendSet(string location, address setter);
+    event StorageBackendRemoved(string location, address remover);
     event ArtifactAdded(bytes32 configHash, address adder);
     event PKIUpdated(address updater, AppPKI pki);
     event IdentityConfigSet(bytes32 identity, bytes32 configHash, address setter);
 
     error ByteSizeExceeded(uint256 size);
-    
+
     /**
      * @dev Constructor to set up initial owner and roles
      */
@@ -72,7 +72,7 @@ contract TEERegistry is Owned, TransientReentrancyGuard {
         IPCCSRouter pccsRouter = IPCCSRouter(0xe20C4d54afBbea5123728d5b7dAcD9CB3c65C39a);
     }
 
-     /**
+    /**
      * @dev Modifier to check if input bytes size is within limits
      */
     modifier limitBytesSize(bytes memory data) {
@@ -85,18 +85,17 @@ contract TEERegistry is Owned, TransientReentrancyGuard {
      * @param pki The PKI (certificate authority, encryption pubkey, kms attestation)
      */
     function setPKI(AppPKI memory pki)
-        public 
-        onlyOwner 
+        public
+        onlyOwner
         limitBytesSize(pki.ca)
         limitBytesSize(pki.pubkey)
         limitBytesSize(pki.attestation)
     {
-		app_pki = pki;
+        app_pki = pki;
         emit PKIUpdated(msg.sender, pki);
     }
 
     function getPKI() external view returns (AppPKI memory) {
-		return app_pki;
-	}
-
+        return app_pki;
+    }
 }

--- a/test/TEERegistry.t.sol
+++ b/test/TEERegistry.t.sol
@@ -6,11 +6,7 @@ import {TEERegistry, AppPKI} from "../src/TEERegistry.sol";
 
 contract TEERegistryTest is Test {
     TEERegistry public registry;
-    AppPKI public appPKI = AppPKI({
-        ca: bytes("0x42"),
-        pubkey: bytes("0x42"),
-        attestation: bytes("0x42")
-    });
+    AppPKI public appPKI = AppPKI({ca: bytes("0x42"), pubkey: bytes("0x42"), attestation: bytes("0x42")});
 
     function setUp() public {
         registry = new TEERegistry(address(this));
@@ -25,11 +21,7 @@ contract TEERegistryTest is Test {
     }
 
     function testFuzz_SetPKI(bytes memory _ca, bytes memory _pubkey, bytes memory _attestation) public {
-        appPKI = AppPKI({
-            ca: _ca,
-            pubkey: _pubkey,
-            attestation: _attestation
-        });
+        appPKI = AppPKI({ca: _ca, pubkey: _pubkey, attestation: _attestation});
         registry.setPKI(appPKI);
         AppPKI memory retrievedPKI = registry.getPKI();
         assertEq0(retrievedPKI.ca, appPKI.ca);


### PR DESCRIPTION
This minimal spec comes from https://github.com/fnerdman/tee-l2-spec/tree/main but with most of the PKI, provisioning, and rollup boost components removed.

Once we implement these parts of the spec, it will be possible to verify if an L2 block was built using a governance-registered TEE device (e.g. Flashbots' remote builder TEE)