### PR TITLE
Add QuoteParser library for parsing TDXQuotes

### DIFF
--- a/script/TEERegistry.s.sol
+++ b/script/TEERegistry.s.sol
@@ -5,6 +5,7 @@ import {Script, console} from "forge-std/Script.sol";
 import {TEERegistry} from "../src/TEERegistry.sol";
 import {AutomataDcapAttestationFee} from "automata-dcap-attestation/contracts/AutomataDcapAttestationFee.sol";
 
+
 contract TEERegistryScript is Script {
     TEERegistry public registry;
     AutomataDcapAttestationFee public attestationFee;

--- a/script/TEERegistry.s.sol
+++ b/script/TEERegistry.s.sol
@@ -5,7 +5,6 @@ import {Script, console} from "forge-std/Script.sol";
 import {TEERegistry} from "../src/TEERegistry.sol";
 import {AutomataDcapAttestationFee} from "automata-dcap-attestation/contracts/AutomataDcapAttestationFee.sol";
 
-
 contract TEERegistryScript is Script {
     TEERegistry public registry;
     AutomataDcapAttestationFee public attestationFee;
@@ -37,7 +36,8 @@ contract TEERegistryScript is Script {
         // Example: Call verifyQuoteWithAttestationFee with a sample quote
         bytes memory sampleQuote = vm.readFileBinary("test/quote.raw");
 
-        (bool success, bytes memory output) = registry.verifyQuoteWithAttestationFee(address(ETHEREUM_SEPOLIA_ATTESTATION_FEE_ADDRESS), sampleQuote);
+        (bool success, bytes memory output) =
+            registry.verifyQuoteWithAttestationFee(address(ETHEREUM_SEPOLIA_ATTESTATION_FEE_ADDRESS), sampleQuote);
 
         if (!success) {
             console.log(string(output));

--- a/src/TEERegistry.sol
+++ b/src/TEERegistry.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.28;
 import "solmate/src/auth/Owned.sol";
 import {TDXLibrary} from "./utils/TDXLibrary.sol";
 import {AutomataDcapAttestationFee} from "../lib/automata-dcap-attestation/evm/contracts/AutomataDcapAttestationFee.sol";
+import {TD10ReportBody} from "automata-dcap-attestation/contracts/types/V4Structs.sol";
 
 /**
  * @title TEERegistry
@@ -92,8 +93,18 @@ contract TEERegistry is Owned {
         returns (bool, bytes memory)
     {
         (bool success, bytes memory output) = AutomataDcapAttestationFee(attestationFeeContract).verifyAndAttestOnChain(quote);
+
         if (success) {
-            isVerified = true;
+            isVerified = true; // TODO: delete this once done testing
+
+            // since the verifyAndAttestOnChain call has succeeded, we can safely
+            // decode the output into the report body struct. We implicitly assume
+            // only V4 TDX quotes will be used here, and not SGX quotes. If you use
+            // anything else, you're on your own
+            TD10ReportBody memory td10ReportBody = abi.decode(output, (TD10ReportBody));
+
+            // TODO do flashtestations protocol, so far we've only verified that the quote is valid
+
         }
 
         return (success, output);

--- a/src/TEERegistry.sol
+++ b/src/TEERegistry.sol
@@ -86,16 +86,20 @@ contract TEERegistry is Owned {
      * @param attestationFeeContract The address of the AutomataDcapAttestationFee contract
      * @param quote The DCAP quote to verify
      */
-    function verifyQuoteWithAttestationFee(address attestationFeeContract, bytes calldata quote) 
+    function verifyQuoteWithAttestationFee(address attestationFeeContract, bytes calldata quote)
         external
         onlyOwner
         limitBytesSize(quote)
         returns (bool, bytes memory)
     {
-        (bool success, bytes memory output) = AutomataDcapAttestationFee(attestationFeeContract).verifyAndAttestOnChain(quote);
+        (bool success, bytes memory output) =
+            AutomataDcapAttestationFee(attestationFeeContract).verifyAndAttestOnChain(quote);
 
         if (success) {
             isVerified = true; // TODO: delete this once done testing
+
+            // TODO: check that quote is v4 and for TDX, look at AttestationEntrypointBase._parseQuoteHeader
+            // for how to get these values from the quote header
 
             // since the verifyAndAttestOnChain call has succeeded, we can safely
             // decode the output into the report body struct. We implicitly assume
@@ -104,7 +108,6 @@ contract TEERegistry is Owned {
             TD10ReportBody memory td10ReportBody = abi.decode(output, (TD10ReportBody));
 
             // TODO do flashtestations protocol, so far we've only verified that the quote is valid
-
         }
 
         return (success, output);

--- a/src/utils/QuoteParser.sol
+++ b/src/utils/QuoteParser.sol
@@ -6,44 +6,36 @@ import {TD10ReportBody} from "automata-dcap-attestation/contracts/types/V4Struct
 library QuoteParser {
     // Intel TDX V4 byte lengths
     uint256 internal constant REPORT_DATA_FIELD_SIZE = 64;
-    uint256 internal constant MIN_TD_REPORT_BODY_LENGTH = 584; // 584 bytes
 
-    // Extracts the Ethereum address from the REPORTDATA field of a TDReport
-    // Assumes the first 20 bytes of REPORTDATA contain the address.
-    function extractAddressFromReportDataBytes(bytes calldata reportDataBytes) internal pure returns (address) {
-        require(reportDataBytes.length == REPORT_DATA_FIELD_SIZE, "QuoteParser: ReportData must be 64 bytes");
-        address addr;
-        // Extract the first 20 bytes for the address
-        assembly {
-            addr := mload(add(reportDataBytes.offset, 0x14)) // Load 32 bytes, address is in lower 20
-            addr := shr(96, addr) // Right shift remaining 12 bytesto get the address (most significant 12 bytes are zeroed out)
+    error InvalidReportDataLength(uint256 length);
+
+    // Extracts the 64-byte Ethereum uncompressed public key (X-coordinate || Y-coordinate) from the
+    // report data field of a TDXQuote
+    function extractPublicKeyFromTDXQuote(TD10ReportBody calldata tdReportBody) internal pure returns (bytes memory) {
+        if (tdReportBody.reportData.length != REPORT_DATA_FIELD_SIZE) {
+            revert InvalidReportDataLength(tdReportBody.reportData.length);
         }
-        return addr;
+        return tdReportBody.reportData;
     }
 
-    function calculateWorkloadIdRaw(
-        bytes memory mrtd,
-        bytes memory rtmr0,
-        bytes memory rtmr1,
-        bytes memory rtmr2,
-        bytes memory rtmr3,
-        bytes memory mrowner,
-        bytes memory mrownerconfig,
-        bytes memory mrconfigid
-    ) internal pure returns (bytes32) {
-        return keccak256(abi.encodePacked(mrtd, rtmr0, rtmr1, rtmr2, rtmr3, mrowner, mrownerconfig, mrconfigid));
+    // Extracts and calculates the address from the public key in the TDXQuote
+    function extractAddressFromTDXQuote(TD10ReportBody calldata tdReportBody) internal pure returns (address) {
+        bytes memory publicKey = extractPublicKeyFromTDXQuote(tdReportBody);
+        return address(uint160(uint256(keccak256(publicKey))));
     }
 
     function calculateWorkloadId(TD10ReportBody calldata tdReportBody) internal pure returns (bytes32) {
-        return calculateWorkloadIdRaw(
-            tdReportBody.mrTd,
-            tdReportBody.rtMr0,
-            tdReportBody.rtMr1,
-            tdReportBody.rtMr2,
-            tdReportBody.rtMr3,
-            tdReportBody.mrOwner,
-            tdReportBody.mrOwnerConfig,
-            tdReportBody.mrConfigId
+        return keccak256(
+            abi.encodePacked(
+                tdReportBody.mrTd,
+                tdReportBody.rtMr0,
+                tdReportBody.rtMr1,
+                tdReportBody.rtMr2,
+                tdReportBody.rtMr3,
+                tdReportBody.mrOwner,
+                tdReportBody.mrOwnerConfig,
+                tdReportBody.mrConfigId
+            )
         );
     }
 }

--- a/src/utils/QuoteParser.sol
+++ b/src/utils/QuoteParser.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {TD10ReportBody} from "automata-dcap-attestation/contracts/types/V4Structs.sol";
+
+library QuoteParser {
+    // Intel TDX V4 byte lengths
+    uint256 internal constant REPORT_DATA_FIELD_SIZE = 64;
+    uint256 internal constant MIN_TD_REPORT_BODY_LENGTH = 584; // 584 bytes
+
+    // Extracts the Ethereum address from the REPORTDATA field of a TDReport
+    // Assumes the first 20 bytes of REPORTDATA contain the address.
+    function extractAddressFromReportDataBytes(bytes calldata reportDataBytes) internal pure returns (address) {
+        require(reportDataBytes.length == REPORT_DATA_FIELD_SIZE, "QuoteParser: ReportData must be 64 bytes");
+        address addr;
+        // Extract the first 20 bytes for the address
+        assembly {
+            addr := mload(add(reportDataBytes.offset, 0x14)) // Load 32 bytes, address is in lower 20
+            addr := shr(96, addr) // Right shift remaining 12 bytesto get the address (most significant 12 bytes are zeroed out)
+        }
+        return addr;
+    }
+
+    function calculateWorkloadIdRaw(
+        bytes memory mrtd,
+        bytes memory rtmr0,
+        bytes memory rtmr1,
+        bytes memory rtmr2,
+        bytes memory rtmr3,
+        bytes memory mrowner,
+        bytes memory mrownerconfig,
+        bytes memory mrconfigid
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(mrtd, rtmr0, rtmr1, rtmr2, rtmr3, mrowner, mrownerconfig, mrconfigid));
+    }
+
+    function calculateWorkloadId(TD10ReportBody calldata tdReportBody) internal pure returns (bytes32) {
+        return calculateWorkloadIdRaw(
+            tdReportBody.mrTd,
+            tdReportBody.rtMr0,
+            tdReportBody.rtMr1,
+            tdReportBody.rtMr2,
+            tdReportBody.rtMr3,
+            tdReportBody.mrOwner,
+            tdReportBody.mrOwnerConfig,
+            tdReportBody.mrConfigId
+        );
+    }
+}


### PR DESCRIPTION
We need a way to extract the data flashtestations will use for the AllowList and workloadIds, and this library does that for us.

It relies heavily on existing parsing logic given by Automata's TD10ReportBody struct