### PR TITLE
add EIP-712 support to verifyBlockBuilderProof

### DIFF
--- a/src/BlockBuilderPolicy.sol
+++ b/src/BlockBuilderPolicy.sol
@@ -5,6 +5,8 @@ import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {EIP712Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {WorkloadId} from "./utils/QuoteParser.sol";
 import {FlashtestationRegistry} from "./FlashtestationRegistry.sol";
 import {TD10ReportBody} from "automata-dcap-attestation/contracts/types/V4Structs.sol";
@@ -20,8 +22,13 @@ import {TD10ReportBody} from "automata-dcap-attestation/contracts/types/V4Struct
  * changes, which is a costly and error-prone process. Instead, consumer contracts need only check if a TEE address
  * is allowed under any workload in a Policy, and the FlashtestationRegistry will handle the rest
  */
-contract BlockBuilderPolicy is Initializable, UUPSUpgradeable, OwnableUpgradeable {
+contract BlockBuilderPolicy is Initializable, UUPSUpgradeable, OwnableUpgradeable, EIP712Upgradeable {
     using EnumerableSet for EnumerableSet.Bytes32Set;
+    using ECDSA for bytes32;
+
+    // EIP-712 Constants
+    bytes32 public constant VERIFY_BLOCK_BUILDER_PROOF_TYPEHASH =
+        keccak256("VerifyBlockBuilderProof(uint8 version,bytes32 blockContentHash,uint256 nonce)");
 
     // The set of workloadIds that are allowed under this policy
     // This is only updateable by governance (i.e. the owner) of the Policy contract.
@@ -42,12 +49,16 @@ contract BlockBuilderPolicy is Initializable, UUPSUpgradeable, OwnableUpgradeabl
     // account for adding new versions to the array
     uint256[] public SUPPORTED_VERSIONS;
 
+    // Tracks nonces for EIP-712 signatures to prevent replay attacks
+    mapping(address => uint256) public nonces;
+
     // Errors
 
     error WorkloadAlreadyInPolicy();
     error WorkloadNotInPolicy();
     error UnauthorizedBlockBuilder(address caller); // the teeAddress is not associated with a valid TEE workload
     error UnsupportedVersion(uint8 version); // see SUPPORTED_VERSIONS for supported versions
+    error InvalidNonce(uint256 expected, uint256 provided);
 
     // Events
 
@@ -62,6 +73,7 @@ contract BlockBuilderPolicy is Initializable, UUPSUpgradeable, OwnableUpgradeabl
      */
     function initialize(address _initialOwner, address _registry) external initializer {
         __Ownable_init(_initialOwner);
+        __EIP712_init("BlockBuilderPolicy", "1");
         registry = _registry;
         SUPPORTED_VERSIONS.push(1);
         emit RegistrySet(_registry);
@@ -76,10 +88,55 @@ contract BlockBuilderPolicy is Initializable, UUPSUpgradeable, OwnableUpgradeabl
     /// and the TEE is running an approved block builder workload (see BlockBuilderPolicy.addWorkloadToPolicy)
     /// @notice The blockContentHash is a keccak256 hash of a subset of the block header, as specified by the version.
     /// See the [flashtestations spec](https://github.com/flashbots/rollup-boost/blob/77fc19f785eeeb9b4eb5fb08463bc556dec2c837/specs/flashtestations.md) for more details
+    /// @dev If you do not want to deal with the operational difficulties of keeping your TEE-controlled
+    /// addresses funded, you can use the permitVerifyBlockBuilderProof function instead which costs
+    /// more gas, but allows any EOA to submit a block builder proof on behalf of a TEE
     function verifyBlockBuilderProof(uint8 version, bytes32 blockContentHash) external {
+        _verifyBlockBuilderProof(msg.sender, version, blockContentHash);
+    }
+
+    /// @notice Verify a block builder proof using EIP-712 signatures
+    /// @param version The version of the flashtestation's protocol used to generate the block builder proof
+    /// @param blockContentHash The hash of the block content
+    /// @param nonce The nonce to use for the EIP-712 signature
+    /// @param eip712Sig The EIP-712 signature of the verification message
+    /// @notice This function allows any EOA to submit a block builder proof on behalf of a TEE
+    /// @notice The TEE must sign a proper EIP-712-formatted message, and the signer must match a TEE-controlled address
+    /// whose associated workload is approved under this policy
+    /// @dev This function is useful if you do not want to deal with the operational difficulties of keeping your
+    /// TEE-controlled addresses funded, but note that because of the larger number of function arguments, will cost
+    /// more gas than the non-EIP-712 verifyBlockBuilderProof function
+    function permitVerifyBlockBuilderProof(
+        uint8 version,
+        bytes32 blockContentHash,
+        uint256 nonce,
+        bytes calldata eip712Sig
+    ) external {
+        // Get the TEE address from the signature
+        bytes32 digest = getHashedTypeDataV4(computeStructHash(version, blockContentHash, nonce));
+        address teeAddress = digest.recover(eip712Sig);
+
+        // Verify the nonce
+        uint256 expectedNonce = nonces[teeAddress];
+        require(nonce == expectedNonce, InvalidNonce(expectedNonce, nonce));
+
+        // Increment the nonce
+        nonces[teeAddress]++;
+
+        // Verify the block builder proof
+        _verifyBlockBuilderProof(teeAddress, version, blockContentHash);
+    }
+
+    /// @notice Internal function to verify a block builder proof
+    /// @param teeAddress The TEE-controlled address
+    /// @param version The version of the flashtestation's protocol
+    /// @param blockContentHash The hash of the block content
+    /// @dev This function is internal because it is only used by the permitVerifyBlockBuilderProof function
+    /// and it is not needed to be called by other contracts
+    function _verifyBlockBuilderProof(address teeAddress, uint8 version, bytes32 blockContentHash) internal {
         require(isSupportedVersion(version), UnsupportedVersion(version));
         // Check if the caller is an authorized TEE block builder for our Policy
-        require(isAllowedPolicy(msg.sender), UnauthorizedBlockBuilder(msg.sender));
+        require(isAllowedPolicy(teeAddress), UnauthorizedBlockBuilder(teeAddress));
 
         // At this point, we know:
         // 1. The caller is a registered TEE-controlled address from an attested TEE
@@ -89,7 +146,7 @@ contract BlockBuilderPolicy is Initializable, UUPSUpgradeable, OwnableUpgradeabl
         // onchain. We rely on the TEE workload to correctly compute this hash according to the
         // specified version of the calculation method.
 
-        emit BlockBuilderProofVerified(msg.sender, block.number, version, blockContentHash);
+        emit BlockBuilderProofVerified(teeAddress, block.number, version, blockContentHash);
     }
 
     /// @notice Helper function to check if a given version is supported by this Policy
@@ -174,5 +231,21 @@ contract BlockBuilderPolicy is Initializable, UUPSUpgradeable, OwnableUpgradeabl
     /// constraint, and so we need to make our own public getter
     function getWorkload(uint256 index) external view returns (bytes32) {
         return workloadIds.at(index);
+    }
+
+    /// @notice Computes the digest for the EIP-712 signature
+    /// @param structHash The struct hash for the EIP-712 signature
+    /// @return The digest for the EIP-712 signature
+    function getHashedTypeDataV4(bytes32 structHash) public view returns (bytes32) {
+        return _hashTypedDataV4(structHash);
+    }
+
+    /// @notice Computes the struct hash for the EIP-712 signature
+    /// @param version The version of the flashtestation's protocol
+    /// @param blockContentHash The hash of the block content
+    /// @param nonce The nonce to use for the EIP-712 signature
+    /// @return The struct hash for the EIP-712 signature
+    function computeStructHash(uint8 version, bytes32 blockContentHash, uint256 nonce) public pure returns (bytes32) {
+        return keccak256(abi.encode(VERIFY_BLOCK_BUILDER_PROOF_TYPEHASH, version, blockContentHash, nonce));
     }
 }

--- a/test/BlockBuilderPolicy.t.sol
+++ b/test/BlockBuilderPolicy.t.sol
@@ -4,8 +4,10 @@ pragma solidity 0.8.28;
 import {Test, console} from "forge-std/Test.sol";
 import {UnsafeUpgrades} from "openzeppelin-foundry-upgrades/Upgrades.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {BlockBuilderPolicy} from "../src/BlockBuilderPolicy.sol";
 import {FlashtestationRegistry, RegisteredTEE} from "../src/FlashtestationRegistry.sol";
+import {MockQuote} from "../test/FlashtestationRegistry.t.sol";
 import {QuoteParser, WorkloadId} from "../src/utils/QuoteParser.sol";
 import {Upgrader} from "./helpers/Upgrader.sol";
 import {MockAutomataDcapAttestationFee} from "./mocks/MockAutomataDcapAttestationFee.sol";
@@ -19,14 +21,7 @@ contract BlockBuilderPolicyTest is Test {
     Upgrader public upgrader = new Upgrader();
     address public owner = address(this);
 
-    // Use the same mock quote structure as FlashtestationRegistry.t.sol
-    struct MockQuote {
-        bytes output;
-        bytes quote;
-        address teeAddress;
-        bytes publicKey;
-        WorkloadId workloadId;
-    }
+    uint8 version = 1;
 
     MockQuote bf42Mock = MockQuote({
         output: vm.readFileBinary(
@@ -37,7 +32,8 @@ contract BlockBuilderPolicyTest is Test {
         ),
         publicKey: hex"bf42a348f49c9f8ab2ef750ddaffd294c45d8adf947e4d1a72158dcdbd6997c2ca7decaa1ad42648efebdfefe79cbc1b63eb2499fe2374648162fd8f5245f446",
         teeAddress: 0xf200f222043C5bC6c70AA6e35f5C5FDe079F3a03,
-        workloadId: WorkloadId.wrap(0xeee0d5f864e6d46d6da790c7d60baac5c8478eb89e86667336d3f17655e9164e)
+        workloadId: WorkloadId.wrap(0xeee0d5f864e6d46d6da790c7d60baac5c8478eb89e86667336d3f17655e9164e),
+        privateKey: 0x0000000000000000000000000000000000000000000000000000000000000000 // unused for this mock
     });
     MockQuote d204Mock = MockQuote({
         output: vm.readFileBinary(
@@ -48,10 +44,26 @@ contract BlockBuilderPolicyTest is Test {
         ),
         publicKey: hex"d204547069c53f9ecff9b30494eb9797615a2f46aa2785db6258104cebb92d48ff4dc0744c36d8470646f4813e61f9a831ffb54b937f7b233f32d271434ccca6",
         teeAddress: 0x12c14e56d585Dcf3B36f37476c00E78bA9363742,
-        workloadId: WorkloadId.wrap(0xeee0d5f864e6d46d6da790c7d60baac5c8478eb89e86667336d3f17655e9164e)
+        workloadId: WorkloadId.wrap(0xeee0d5f864e6d46d6da790c7d60baac5c8478eb89e86667336d3f17655e9164e),
+        privateKey: 0x0000000000000000000000000000000000000000000000000000000000000000 // unused for this mock
     });
+    MockQuote mock7b91 = MockQuote({
+        output: vm.readFileBinary(
+            "test/raw_tdx_quotes/7b916d70ed77488d6c1ced7117ba410655a8faa8d6c7740562a88ab3cb9cbca63e2d5761812a11d90c009ed017113131370070cd3a2d5fba64d9dbb76952df19/output.bin"
+        ),
+        quote: vm.readFileBinary(
+            "test/raw_tdx_quotes/7b916d70ed77488d6c1ced7117ba410655a8faa8d6c7740562a88ab3cb9cbca63e2d5761812a11d90c009ed017113131370070cd3a2d5fba64d9dbb76952df19/quote.bin"
+        ),
+        publicKey: hex"7b916d70ed77488d6c1ced7117ba410655a8faa8d6c7740562a88ab3cb9cbca63e2d5761812a11d90c009ed017113131370070cd3a2d5fba64d9dbb76952df19",
+        teeAddress: 0x46f6b3ACF1dD8Ac0085e30192741336c4aF6EdAF,
+        workloadId: WorkloadId.wrap(0xeee0d5f864e6d46d6da790c7d60baac5c8478eb89e86667336d3f17655e9164e),
+        privateKey: 0x92e4b5ed61db615b26da2271da5b47c42d691b3164561cfb4edbc85ca6ca61a8
+    });
+
     WorkloadId arbitraryWorkloadId = WorkloadId.wrap(0x1dd337a1486a84a7d4200553584996abec87a87473d445262d5562f84ec456a8);
     WorkloadId wrongWorkloadId = WorkloadId.wrap(0x20ab431377d40de192f7c754ac0f1922de05ab2f73e74204f0b3ab73a8856876);
+
+    using ECDSA for bytes32;
 
     function setUp() public {
         attestationContract = new MockAutomataDcapAttestationFee();
@@ -266,5 +278,136 @@ contract BlockBuilderPolicyTest is Test {
 
         // Verify the implementation was updated
         assertEq(upgrader.getImplementation(address(policy)), newImplementation);
+    }
+
+    function test_successful_permitVerifyBlockBuilderProof() public {
+        address teeAddress = mock7b91.teeAddress;
+        bytes32 blockContentHash = Helper.computeFlashtestationBlockContentHash();
+
+        // Register TEE and add workload to policy
+        _registerTEE(mock7b91);
+        policy.addWorkloadToPolicy(mock7b91.workloadId);
+
+        // Create the EIP-712 signature
+        bytes32 structHash = policy.computeStructHash(version, blockContentHash, 0);
+        bytes32 digest = policy.getHashedTypeDataV4(structHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(mock7b91.privateKey, digest);
+        bytes memory signature = abi.encodePacked(r, s, v);
+
+        // Expect the event to be emitted
+        vm.expectEmit(address(policy));
+        emit BlockBuilderPolicy.BlockBuilderProofVerified(teeAddress, block.number, version, blockContentHash);
+
+        // Call the function
+        policy.permitVerifyBlockBuilderProof(version, blockContentHash, 0, signature);
+
+        // Verify nonce was incremented
+        assertEq(policy.nonces(teeAddress), 1, "Nonce should be incremented");
+    }
+
+    function test_successful_permitVerifyBlockBuilderProof_multiple_times() public {
+        address teeAddress = mock7b91.teeAddress;
+        bytes32 blockContentHash = Helper.computeFlashtestationBlockContentHash();
+
+        // Register TEE and add workload to policy
+        _registerTEE(mock7b91);
+        policy.addWorkloadToPolicy(mock7b91.workloadId);
+
+        // Create the EIP-712 signature
+        bytes32 structHash = policy.computeStructHash(version, blockContentHash, 0);
+        bytes32 digest = policy.getHashedTypeDataV4(structHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(mock7b91.privateKey, digest);
+        bytes memory signature = abi.encodePacked(r, s, v);
+
+        // Expect the event to be emitted
+        vm.expectEmit(address(policy));
+        emit BlockBuilderPolicy.BlockBuilderProofVerified(teeAddress, block.number, version, blockContentHash);
+
+        // Call the function
+        policy.permitVerifyBlockBuilderProof(version, blockContentHash, 0, signature);
+
+        // Verify nonce was incremented
+        assertEq(policy.nonces(teeAddress), 1, "Nonce should be incremented");
+
+        // now build the sign and call the function again with the subsequent nonce
+
+        structHash = policy.computeStructHash(version, blockContentHash, 1);
+        digest = policy.getHashedTypeDataV4(structHash);
+        (v, r, s) = vm.sign(mock7b91.privateKey, digest);
+        signature = abi.encodePacked(r, s, v);
+
+        // Expect the event to be emitted
+        vm.expectEmit(address(policy));
+        emit BlockBuilderPolicy.BlockBuilderProofVerified(teeAddress, block.number, version, blockContentHash);
+
+        // Call the function
+        policy.permitVerifyBlockBuilderProof(version, blockContentHash, 1, signature);
+
+        // Verify nonce was incremented
+        assertEq(policy.nonces(teeAddress), 2, "Nonce should be incremented");
+    }
+
+    function test_permitVerifyBlockBuilderProof_reverts_with_unauthorized_block_builder() public {
+        bytes32 blockContentHash = Helper.computeFlashtestationBlockContentHash();
+
+        // Create signature with wrong private key
+        (address invalid_signer, uint256 invalid_pk) = makeAddrAndKey("invalid_signer");
+
+        bytes32 structHash = policy.computeStructHash(version, blockContentHash, 0);
+        bytes32 digest = policy.getHashedTypeDataV4(structHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(invalid_pk, digest);
+        bytes memory signature = abi.encodePacked(r, s, v);
+
+        vm.expectRevert(abi.encodeWithSelector(BlockBuilderPolicy.UnauthorizedBlockBuilder.selector, invalid_signer));
+        policy.permitVerifyBlockBuilderProof(version, blockContentHash, 0, signature);
+    }
+
+    function test_permitVerifyBlockBuilderProof_reverts_with_invalid_nonce() public {
+        bytes32 blockContentHash = Helper.computeFlashtestationBlockContentHash();
+
+        // Create signature with wrong nonce
+        bytes32 structHash = policy.computeStructHash(version, blockContentHash, 1); // wrong nonce
+        bytes32 digest = policy.getHashedTypeDataV4(structHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(mock7b91.privateKey, digest);
+        bytes memory signature = abi.encodePacked(r, s, v);
+
+        vm.expectRevert(abi.encodeWithSelector(BlockBuilderPolicy.InvalidNonce.selector, 0, 1));
+        policy.permitVerifyBlockBuilderProof(version, blockContentHash, 1, signature);
+    }
+
+    function test_permitVerifyBlockBuilderProof_reverts_with_replayed_signature() public {
+        address teeAddress = mock7b91.teeAddress;
+        bytes32 blockContentHash = Helper.computeFlashtestationBlockContentHash();
+
+        // Register TEE and add workload to policy
+        _registerTEE(mock7b91);
+        policy.addWorkloadToPolicy(mock7b91.workloadId);
+
+        // Create the EIP-712 signature
+        bytes32 structHash = policy.computeStructHash(version, blockContentHash, 0);
+        bytes32 digest = policy.getHashedTypeDataV4(structHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(mock7b91.privateKey, digest);
+        bytes memory signature = abi.encodePacked(r, s, v);
+
+        // First verification should succeed
+        policy.permitVerifyBlockBuilderProof(version, blockContentHash, 0, signature);
+
+        // Try to replay the same signature
+        vm.expectRevert(abi.encodeWithSelector(BlockBuilderPolicy.InvalidNonce.selector, 1, 0));
+        policy.permitVerifyBlockBuilderProof(version, blockContentHash, 0, signature);
+    }
+
+    function test_permitVerifyBlockBuilderProof_reverts_with_unsupported_version() public {
+        bytes32 blockContentHash = Helper.computeFlashtestationBlockContentHash();
+
+        // Create signature with unsupported version
+        uint8 unsupportedVersion = 2;
+        bytes32 structHash = policy.computeStructHash(unsupportedVersion, blockContentHash, 0);
+        bytes32 digest = policy.getHashedTypeDataV4(structHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(mock7b91.privateKey, digest);
+        bytes memory signature = abi.encodePacked(r, s, v);
+
+        vm.expectRevert(abi.encodeWithSelector(BlockBuilderPolicy.UnsupportedVersion.selector, unsupportedVersion));
+        policy.permitVerifyBlockBuilderProof(unsupportedVersion, blockContentHash, 0, signature);
     }
 }

--- a/test/helpers/Helper.sol
+++ b/test/helpers/Helper.sol
@@ -409,4 +409,12 @@ library Helper {
     function concat(string memory a, string memory b) internal pure returns (string memory) {
         return string(abi.encodePacked(a, b));
     }
+
+    /// @dev Simple helper function to simulate the block content hash computation
+    /// for the flashtestation protocol. This is used to test the BlockBuilderPolicy contract.
+    function computeFlashtestationBlockContentHash() internal view returns (bytes32) {
+        string[] memory txHashes = new string[](0);
+        bytes32 parentHash = blockhash(block.number - 1);
+        return keccak256(abi.encode(parentHash, block.number, block.timestamp, txHashes));
+    }
 }


### PR DESCRIPTION
This helps simplify tx fee gas management for the TEE, because it does not need to ever be funded with ETH for tx fees, and instead can rely on any arbitrary EOA to pass along its signature in a call to permitVerifyBlockBuilderProof.

* permitVerifyBlockBuilderProof, still need to write tests
* add tests for permitVerifyBlockBuilderProof