### PR TITLE
[not canonical] Moves workloadId to builder policy, adjusts registry to accept extended user data

### DIFF
--- a/src/BlockBuilderPolicy.sol
+++ b/src/BlockBuilderPolicy.sol
@@ -181,21 +181,21 @@ contract BlockBuilderPolicy is Initializable, UUPSUpgradeable, OwnableUpgradeabl
     /// @return allowed True if the TEE is valid for any workload in the policy
     /// @return workloadId The workloadId of the TEE that is valid for the policy, or 0 if the TEE is not valid for any workload in the policy
     function isAllowedPolicy(address teeAddress) public view returns (bool allowed, WorkloadId) {
-		RegisteredTEE registration, bool isValid = FlashtestationRegistry(registry).getRegistration(teeAddress)
-		if (!isValid) {
-			return (false, WorkloadId.wrap(0));
-		}
-		WorkloadId workloadId = workloadIdFromRegistration(registration);
+        RegisteredTEE registration, bool isValid = FlashtestationRegistry(registry).getRegistration(teeAddress)
+        if (!isValid) {
+            return (false, WorkloadId.wrap(0));
+        }
+        WorkloadId workloadId = workloadIdFromRegistration(registration);
 
         for (uint256 i = 0; i < workloadIds.length(); ++i) {
-			if (workloadId == WorkloadId.wrap(workloadIds.at(i))) {
-				return (true, workloadId);
-			}
+            if (workloadId == WorkloadId.wrap(workloadIds.at(i))) {
+                return (true, workloadId);
+            }
         }
         return (false, WorkloadId.wrap(0));
     }
 
-	// Application specific mapping of registration data, in particular the quote and attested user data, to a workload identifier
+    // Application specific mapping of registration data, in particular the quote and attested user data, to a workload identifier
     function workloadIdFromRegistration(RegisteredTEE memory registration) internal pure returns (WorkloadId) {
         return WorkloadId.wrap(
             keccak256(
@@ -224,19 +224,19 @@ contract BlockBuilderPolicy is Initializable, UUPSUpgradeable, OwnableUpgradeabl
     /// @dev This exists to show how different Policies can be implemented, based on what
     /// properties of the TEE's attestation are important to verify.
     function isAllowedPolicy2(address teeAddress, bytes16 expectedTeeTcbSvn) external view returns (bool allowed) {
-		RegisteredTEE registration, bool isValid = FlashtestationRegistry(registry).getRegistration(teeAddress)
-		if (!isValid) {
-			return (false, WorkloadId.wrap(0));
-		}
-		WorkloadId workloadId = workloadIdFromRegistration(registration);
+        RegisteredTEE registration, bool isValid = FlashtestationRegistry(registry).getRegistration(teeAddress)
+        if (!isValid) {
+            return (false, WorkloadId.wrap(0));
+        }
+        WorkloadId workloadId = workloadIdFromRegistration(registration);
 
         for (uint256 i = 0; i < workloadIds.length(); ++i) {
-			if (workloadId == WorkloadId.wrap(workloadIds.at(i))) {
-				TD10ReportBody memory reportBody = FlashtestationRegistry(registry).getReportBody(teeAddress);
-				if (reportBody.teeTcbSvn == expectedTeeTcbSvn) {
-					return true;
-				}
-			}
+            if (workloadId == WorkloadId.wrap(workloadIds.at(i))) {
+                TD10ReportBody memory reportBody = FlashtestationRegistry(registry).getReportBody(teeAddress);
+                if (reportBody.teeTcbSvn == expectedTeeTcbSvn) {
+                    return true;
+                }
+            }
         }
 
         return false;

--- a/src/FlashtestationRegistry.sol
+++ b/src/FlashtestationRegistry.sol
@@ -19,78 +19,78 @@ import {TD_REPORT10_LENGTH, HEADER_LENGTH} from "automata-dcap-attestation/contr
  * using Automata's Intel DCAP attestation
  */
 contract FlashtestationRegistry is
-    IFlashtestationRegistry,
-    Initializable,
-    UUPSUpgradeable,
-    OwnableUpgradeable,
-    EIP712Upgradeable,
-    ReentrancyGuardTransient
+	IFlashtestationRegistry,
+	Initializable,
+	UUPSUpgradeable,
+	OwnableUpgradeable,
+	EIP712Upgradeable,
+	ReentrancyGuardTransient
 {
-    using ECDSA for bytes32;
+	using ECDSA for bytes32;
 
-    // Constants
+	// Constants
 
-    // Maximum size for byte arrays to prevent DoS attacks
-    uint256 public constant MAX_BYTES_SIZE = 20 * 1024; // 20KB limit
+	// Maximum size for byte arrays to prevent DoS attacks
+	uint256 public constant MAX_BYTES_SIZE = 20 * 1024; // 20KB limit
 
-    // EIP-712 Constants
-    bytes32 public constant REGISTER_TYPEHASH = keccak256("RegisterTEEService(bytes rawQuote,uint256 nonce)");
+	// EIP-712 Constants
+	bytes32 public constant REGISTER_TYPEHASH = keccak256("RegisterTEEService(bytes rawQuote,uint256 nonce)");
 
-    // Storage Variables
+	// Storage Variables
 
-    // The address of the Automata DCAP Attestation contract, which verifies TEE quotes.
-    // This is deployed by Automata, and once set on the FlashtestationRegistry, it cannot be changed
-    IAttestation public attestationContract;
+	// The address of the Automata DCAP Attestation contract, which verifies TEE quotes.
+	// This is deployed by Automata, and once set on the FlashtestationRegistry, it cannot be changed
+	IAttestation public attestationContract;
 
-    // Tracks the TEE-controlled address that registered a particular WorkloadId and attestation quote.
-    // This enables efficient O(1) lookup in `getRegistration`, so that apps can quickly verify the
-    // output of a TEE workload
-    mapping(address => RegisteredTEE) public registeredTEEs;
+	// Tracks the TEE-controlled address that registered a particular WorkloadId and attestation quote.
+	// This enables efficient O(1) lookup in `getRegistration`, so that apps can quickly verify the
+	// output of a TEE workload
+	mapping(address => RegisteredTEE) public registeredTEEs;
 
-    // Tracks nonces for EIP-712 signatures to prevent replay attacks
-    mapping(address => uint256) public nonces;
+	// Tracks nonces for EIP-712 signatures to prevent replay attacks
+	mapping(address => uint256) public nonces;
 
-    // Gap for future contract upgrades
-    uint256[48] __gap;
+	// Gap for future contract upgrades
+	uint256[48] __gap;
 
-    /**
-     * Initializer to set the Automata DCAP Attestation contract, which verifies TEE quotes
-     * @param _attestationContract The address of the attestation contract
-     */
-    function initialize(address owner, address _attestationContract) external initializer {
-        __Ownable_init(owner);
-        __EIP712_init("FlashtestationRegistry", "1");
-        attestationContract = IAttestation(_attestationContract);
-    }
+	/**
+	 * Initializer to set the Automata DCAP Attestation contract, which verifies TEE quotes
+	 * @param _attestationContract The address of the attestation contract
+	 */
+	function initialize(address owner, address _attestationContract) external initializer {
+		__Ownable_init(owner);
+		__EIP712_init("FlashtestationRegistry", "1");
+		attestationContract = IAttestation(_attestationContract);
+	}
 
-    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
+	function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
 
-    /**
-     * @dev Modifier to check if input bytes size is within limits
-     * to protect against DoS attacks
-     */
-    modifier limitBytesSize(bytes memory data) {
-        require(data.length <= MAX_BYTES_SIZE, ByteSizeExceeded(data.length));
-        _;
-    }
+	/**
+	 * @dev Modifier to check if input bytes size is within limits
+	 * to protect against DoS attacks
+	 */
+	modifier limitBytesSize(bytes memory data) {
+		require(data.length <= MAX_BYTES_SIZE, ByteSizeExceeded(data.length));
+		_;
+	}
 
-    /**
-     * @notice Registers a TEE workload with a specific TEE-controlled address in the FlashtestationRegistry
-     * @notice The TEE must be registered with a quote whose validity is verified by the attestationContract
-     * @dev In order to mitigate DoS attacks, the quote must be less than 20KB
-     * @dev This is a costly operation (5 million gas) and should be used sparingly.
-     * @param rawQuote The raw quote from the TEE device. Must be a V4 TDX quote
-     */
-    function registerTEEService(bytes calldata rawQuote, bytes calldata userData) external limitBytesSize(rawQuote) nonReentrant {
-        (bool success, bytes memory output) = attestationContract.verifyAndAttestOnChain(rawQuote);
+	/**
+	 * @notice Registers a TEE workload with a specific TEE-controlled address in the FlashtestationRegistry
+	 * @notice The TEE must be registered with a quote whose validity is verified by the attestationContract
+	 * @dev In order to mitigate DoS attacks, the quote must be less than 20KB
+	 * @dev This is a costly operation (5 million gas) and should be used sparingly.
+	 * @param rawQuote The raw quote from the TEE device. Must be a V4 TDX quote
+	 */
+	function registerTEEService(bytes calldata rawQuote, bytes calldata userData) external limitBytesSize(rawQuote) nonReentrant {
+		(bool success, bytes memory output) = attestationContract.verifyAndAttestOnChain(rawQuote);
 
-        if (!success) {
-            revert InvalidQuote(output);
-        }
+		if (!success) {
+			revert InvalidQuote(output);
+		}
 
-        // now we know the quote is valid, we can safely parse the output into the TDX report body,
-        // from which we'll extract the data we need to register the TEE
-        TD10ReportBody memory td10ReportBodyStruct = QuoteParser.parseV4VerifierOutput(output);
+		// now we know the quote is valid, we can safely parse the output into the TDX report body,
+		// from which we'll extract the data we need to register the TEE
+		TD10ReportBody memory td10ReportBodyStruct = QuoteParser.parseV4VerifierOutput(output);
 
 		// Ensures the TEE intends to register with this specific contract
 		require(td10ReportBodyStruct.reportData[0:20] == address(this);
@@ -98,217 +98,217 @@ contract FlashtestationRegistry is
 		// Cryptographically binding the extended user data to the quote
 		require(td10ReportBodyStruct.reportData[20:52] == keccak256(userData));
 
-        bytes memory publicKey = userData;
-        address teeAddress = address(uint160(uint256(keccak256(publicKey))));
+		bytes memory publicKey = userData;
+		address teeAddress = address(uint160(uint256(keccak256(publicKey))));
 
-        // we must ensure the TEE-controlled address is the same as the one calling the function
-        // otherwise we have no proof that the TEE that generated this quote intends to register
-        // with the FlashtestationRegistry. This protects against a malicious TEE that generates a quote for a
-        // different address, and then calls this function to register itself with the FlashtestationRegistry
-        if (teeAddress != msg.sender) {
-            revert SenderMustMatchTEEAddress(msg.sender, teeAddress);
-        }
+		// we must ensure the TEE-controlled address is the same as the one calling the function
+		// otherwise we have no proof that the TEE that generated this quote intends to register
+		// with the FlashtestationRegistry. This protects against a malicious TEE that generates a quote for a
+		// different address, and then calls this function to register itself with the FlashtestationRegistry
+		if (teeAddress != msg.sender) {
+			revert SenderMustMatchTEEAddress(msg.sender, teeAddress);
+		}
 
-        bool previouslyRegistered = checkIfPreviouslyRegistered(teeAddress, rawQuote);
+		bool previouslyRegistered = checkIfPreviouslyRegistered(teeAddress, rawQuote);
 
-        // Register the address in the registry with the raw quote so later on if the TEE has its
-        // underlying DCAP endorsements updated, we can invalidate the TEE's attestation
-        registeredTEEs[teeAddress] =
-            RegisteredTEE({parsedReportBody: td10ReportBodyStruct, rawQuote: rawQuote, userData: userData, isValid: true});
+		// Register the address in the registry with the raw quote so later on if the TEE has its
+		// underlying DCAP endorsements updated, we can invalidate the TEE's attestation
+		registeredTEEs[teeAddress] =
+			RegisteredTEE({parsedReportBody: td10ReportBodyStruct, rawQuote: rawQuote, userData: userData, isValid: true});
 
-        emit TEEServiceRegistered(teeAddress, rawQuote, userData, previouslyRegistered);
-    }
+		emit TEEServiceRegistered(teeAddress, rawQuote, userData, previouslyRegistered);
+	}
 
-    /**
-     * @notice Registers a TEE workload with a specific TEE-controlled address using EIP-712 signatures
-     * @notice The TEE must be registered with a quote whose validity is verified by the attestationContract
-     * @dev In order to mitigate DoS attacks, the quote must be less than 20KB
-     * @dev This function exists so that the TEE does not need to be funded with gas for transaction fees, and
-     * instead can rely on any EOA to execute the transaction, but still only allow quotes from attested TEEs
-     * @param rawQuote The raw quote from the TEE device. Must be a V4 TDX quote
-     * @param userData Use-case specific data that supplements TEE quote ReportData
-     * @param nonce The nonce to use for the EIP-712 signature (to prevent replay attacks)
-     * @param signature The EIP-712 signature of the registration message
-     */
-    function permitRegisterTEEService(bytes calldata rawQuote, bytes calldata userData, uint256 nonce, bytes calldata signature)
-        external
-        limitBytesSize(rawQuote)
-        limitBytesSize(userData)
-        nonReentrant
-    {
-        // Verify the quote with the attestation contract
-        (bool success, bytes memory output) = attestationContract.verifyAndAttestOnChain(rawQuote);
+	/**
+	 * @notice Registers a TEE workload with a specific TEE-controlled address using EIP-712 signatures
+	 * @notice The TEE must be registered with a quote whose validity is verified by the attestationContract
+	 * @dev In order to mitigate DoS attacks, the quote must be less than 20KB
+	 * @dev This function exists so that the TEE does not need to be funded with gas for transaction fees, and
+	 * instead can rely on any EOA to execute the transaction, but still only allow quotes from attested TEEs
+	 * @param rawQuote The raw quote from the TEE device. Must be a V4 TDX quote
+	 * @param userData Use-case specific data that supplements TEE quote ReportData
+	 * @param nonce The nonce to use for the EIP-712 signature (to prevent replay attacks)
+	 * @param signature The EIP-712 signature of the registration message
+	 */
+	function permitRegisterTEEService(bytes calldata rawQuote, bytes calldata userData, uint256 nonce, bytes calldata signature)
+		external
+		limitBytesSize(rawQuote)
+		limitBytesSize(userData)
+		nonReentrant
+	{
+		// Verify the quote with the attestation contract
+		(bool success, bytes memory output) = attestationContract.verifyAndAttestOnChain(rawQuote);
 
-        if (!success) {
-            revert InvalidQuote(output);
-        }
+		if (!success) {
+			revert InvalidQuote(output);
+		}
 
-        // now we know the quote is valid, we can safely parse the output into the TDX report body,
-        // from which we'll extract the data we need to register the TEE
-        TD10ReportBody memory td10ReportBodyStruct = QuoteParser.parseV4VerifierOutput(output);
+		// now we know the quote is valid, we can safely parse the output into the TDX report body,
+		// from which we'll extract the data we need to register the TEE
+		TD10ReportBody memory td10ReportBodyStruct = QuoteParser.parseV4VerifierOutput(output);
 
 		// With aux userData we should expect the reportData to always be hash of userData
 		require(td10ReportBodyStruct.reportData[0:32] == keccak256(userData));
-        bytes memory publicKey = abi.decode(userData, (bytes,)); // app-specific userData structure. We can also accept versioned bytes, or a strongly typed structure
-        address teeAddress = address(uint160(uint256(keccak256(publicKey))));
+		bytes memory publicKey = abi.decode(userData, (bytes,)); // app-specific userData structure. We can also accept versioned bytes, or a strongly typed structure
+		address teeAddress = address(uint160(uint256(keccak256(publicKey))));
 
-        // we must ensure the TEE-controlled address is the same as the one who signed the EIP-712 signature
-        // otherwise we have no proof that the TEE that generated this quote intends to register
-        // with the FlashtestationRegistry. This protects against a malicious TEE that generates a quote for a
-        // different address, and then calls this function to register itself with the FlashtestationRegistry
+		// we must ensure the TEE-controlled address is the same as the one who signed the EIP-712 signature
+		// otherwise we have no proof that the TEE that generated this quote intends to register
+		// with the FlashtestationRegistry. This protects against a malicious TEE that generates a quote for a
+		// different address, and then calls this function to register itself with the FlashtestationRegistry
 
-        // Verify the nonce
-        uint256 expectedNonce = nonces[teeAddress];
-        require(nonce == expectedNonce, InvalidNonce(expectedNonce, nonce));
+		// Verify the nonce
+		uint256 expectedNonce = nonces[teeAddress];
+		require(nonce == expectedNonce, InvalidNonce(expectedNonce, nonce));
 
-        // Increment the nonce so that any attempts at replaying this transaction will fail
-        nonces[teeAddress]++;
+		// Increment the nonce so that any attempts at replaying this transaction will fail
+		nonces[teeAddress]++;
 
-        // Create the digest using EIP712Upgradeable's _hashTypedDataV4
-        bytes32 digest = _hashTypedDataV4(computeStructHash(rawQuote, userData, nonce));
+		// Create the digest using EIP712Upgradeable's _hashTypedDataV4
+		bytes32 digest = _hashTypedDataV4(computeStructHash(rawQuote, userData, nonce));
 
-        // Recover the signer, and ensure it matches the TEE-controlled address, otherwise we have no proof
-        // that the TEE that generated this quote intends to register with the FlashtestationRegistry
-        address signer = digest.recover(signature);
-        if (signer != teeAddress) {
-            revert InvalidSignature();
-        }
+		// Recover the signer, and ensure it matches the TEE-controlled address, otherwise we have no proof
+		// that the TEE that generated this quote intends to register with the FlashtestationRegistry
+		address signer = digest.recover(signature);
+		if (signer != teeAddress) {
+			revert InvalidSignature();
+		}
 
-        bool previouslyRegistered = checkIfPreviouslyRegistered(teeAddress, rawQuote);
+		bool previouslyRegistered = checkIfPreviouslyRegistered(teeAddress, rawQuote);
 
-        // Register the address in the registry with the raw quote so later on if the TEE has its
-        // underlying DCAP endorsements updated, we can invalidate the TEE's attestation
-        registeredTEEs[teeAddress] =
-            RegisteredTEE({parsedReportBody: td10ReportBodyStruct, rawQuote: rawQuote, userData: userData, isValid: true});
+		// Register the address in the registry with the raw quote so later on if the TEE has its
+		// underlying DCAP endorsements updated, we can invalidate the TEE's attestation
+		registeredTEEs[teeAddress] =
+			RegisteredTEE({parsedReportBody: td10ReportBodyStruct, rawQuote: rawQuote, userData: userData, isValid: true});
 
-        emit TEEServiceRegistered(teeAddress, rawQuote, userData, previouslyRegistered);
-    }
+		emit TEEServiceRegistered(teeAddress, rawQuote, userData, previouslyRegistered);
+	}
 
-    /**
-     * @notice Checks if a TEE is already registered with the same quote
-     * @dev If a user is trying to add the same address, and quote, this is a no-op
-     * and we should revert to signal that the user may be making a mistake (why would
-     * they be trying to add the same TEE twice?).
-     * @dev If the TEE is already registered and we're using a different quote,
-     * that is fine and indicates the TEE-controlled address is either re-attesting
-     * (with a new quote) or has moved its private key to a new TEE device
-     * @dev We do not need to check the public key, because the address has a cryptographically-ensured
-     * 1-to-1 relationship with the public key, so checking it would be redundant
-     * @param teeAddress The TEE-controlled address of the TEE
-     * @param rawQuote The raw quote from the TEE device
-     * @return Whether the TEE is already registered but is updating its quote
-     */
-    function checkIfPreviouslyRegistered(address teeAddress, bytes calldata rawQuote)
-        internal
-        view
-        returns (bool)
-    {
-        if (
+	/**
+	 * @notice Checks if a TEE is already registered with the same quote
+	 * @dev If a user is trying to add the same address, and quote, this is a no-op
+	 * and we should revert to signal that the user may be making a mistake (why would
+	 * they be trying to add the same TEE twice?).
+	 * @dev If the TEE is already registered and we're using a different quote,
+	 * that is fine and indicates the TEE-controlled address is either re-attesting
+	 * (with a new quote) or has moved its private key to a new TEE device
+	 * @dev We do not need to check the public key, because the address has a cryptographically-ensured
+	 * 1-to-1 relationship with the public key, so checking it would be redundant
+	 * @param teeAddress The TEE-controlled address of the TEE
+	 * @param rawQuote The raw quote from the TEE device
+	 * @return Whether the TEE is already registered but is updating its quote
+	 */
+	function checkIfPreviouslyRegistered(address teeAddress, bytes calldata rawQuote)
+		internal
+		view
+		returns (bool)
+	{
+		if (
 			keccak256(registeredTEEs[teeAddress].rawQuote) == keccak256(rawQuote)
-        ) {
-            revert TEEServiceAlreadyRegistered(teeAddress, rawQuote);
-        }
+		) {
+			revert TEEServiceAlreadyRegistered(teeAddress, rawQuote);
+		}
 
-        // if the TEE is already registered, but we're using a different quote,
-        // return true to signal that the TEE is already registered but is updating its quote
-        return WorkloadId.unwrap(registeredTEEs[teeAddress].) != 0;
-    }
+		// if the TEE is already registered, but we're using a different quote,
+		// return true to signal that the TEE is already registered but is updating its quote
+		return WorkloadId.unwrap(registeredTEEs[teeAddress].) != 0;
+	}
 
-    /**
-     * @notice Fetches TEE registration for a given address
-     * @param teeAddress The TEE-controlled address to check
-     * @return Raw quote, and whether the TEE registration has not been invalidated
-     * @dev getRegistration will only return true if a valid TEE quote containing
-     * teeAddress in its reportData field was previously registered with the FlashtestationRegistry
-     * using the registerTEEService function.
-     */
-    function getRegistration(address teeAddress) public view returns (bool, RegisteredTEE memory) {
-        return registeredTEEs[teeAddress].isValid, registeredTEEs[teeAddress];
-    }
+	/**
+	 * @notice Fetches TEE registration for a given address
+	 * @param teeAddress The TEE-controlled address to check
+	 * @return Raw quote, and whether the TEE registration has not been invalidated
+	 * @dev getRegistration will only return true if a valid TEE quote containing
+	 * teeAddress in its reportData field was previously registered with the FlashtestationRegistry
+	 * using the registerTEEService function.
+	 */
+	function getRegistration(address teeAddress) public view returns (bool, RegisteredTEE memory) {
+		return registeredTEEs[teeAddress].isValid, registeredTEEs[teeAddress];
+	}
 
-    /**
-     * @notice Invalidates the attestation of a TEE
-     * @param teeAddress The TEE-controlled address to invalidate
-     * @dev This is a costly operation (5 million gas) and should be used sparingly.
-     * @dev Will always revert except if the attestation is valid and the attestation re-verification
-     * fails. This is to prevent a user needlessly calling this function and for a no-op to occur
-     * @dev This function exists to handle an important security requirement: occasionally Intel
-     * will release a new set of DCAP Endorsements for a particular TEE setup (for instance if a
-     * TDX vulnerability was discovered), which invalidates all prior quotes generated by that TEE.
-     * By invalidates we mean that the outputs generated by the TEE-controlled address associated
-     * with these invalid quotes are no longer secure and cannot be relied upon. This fact needs to be
-     * reflected onchain, so that any upstream contracts that try to call `getRegistration` will
-     * correctly return `false` for the TEE-controlled addresses associated with these invalid quotes.
-     * This is a security requirement to ensure that no downstream contracts can be exploited by
-     * a malicious TEE that has been compromised
-     * @dev Note: this function is callable by anyone, so that offchain monitoring services can
-     * quickly mark TEEs as invalid
+	/**
+	 * @notice Invalidates the attestation of a TEE
+	 * @param teeAddress The TEE-controlled address to invalidate
+	 * @dev This is a costly operation (5 million gas) and should be used sparingly.
+	 * @dev Will always revert except if the attestation is valid and the attestation re-verification
+	 * fails. This is to prevent a user needlessly calling this function and for a no-op to occur
+	 * @dev This function exists to handle an important security requirement: occasionally Intel
+	 * will release a new set of DCAP Endorsements for a particular TEE setup (for instance if a
+	 * TDX vulnerability was discovered), which invalidates all prior quotes generated by that TEE.
+	 * By invalidates we mean that the outputs generated by the TEE-controlled address associated
+	 * with these invalid quotes are no longer secure and cannot be relied upon. This fact needs to be
+	 * reflected onchain, so that any upstream contracts that try to call `getRegistration` will
+	 * correctly return `false` for the TEE-controlled addresses associated with these invalid quotes.
+	 * This is a security requirement to ensure that no downstream contracts can be exploited by
+	 * a malicious TEE that has been compromised
+	 * @dev Note: this function is callable by anyone, so that offchain monitoring services can
+	 * quickly mark TEEs as invalid
 	 * @dev Note: rather than relying on invalidation of specific quotes, we can cover all the cases
 	 * in which a quote can be invalidated (tcbrecovery, certificate revocation etc). This would allow
 	 * much cheaper, bulk invalidation of all quotes using a now-outdated tcbinfo for example.
-     */
-    function invalidateAttestation(address teeAddress) external {
-        // check to make sure it even makes sense to invalidate the TEE-controlled address
-        // if the TEE-controlled address is not registered with the FlashtestationRegistry,
-        // it doesn't make sense to invalidate the attestation
-        RegisteredTEE memory registeredTEE = registeredTEEs[teeAddress];
-        if (registeredTEE.rawQuote.length == 0) { // TODO
-            revert TEEServiceNotRegistered(teeAddress);
-        }
+	 */
+	function invalidateAttestation(address teeAddress) external {
+		// check to make sure it even makes sense to invalidate the TEE-controlled address
+		// if the TEE-controlled address is not registered with the FlashtestationRegistry,
+		// it doesn't make sense to invalidate the attestation
+		RegisteredTEE memory registeredTEE = registeredTEEs[teeAddress];
+		if (registeredTEE.rawQuote.length == 0) { // TODO
+			revert TEEServiceNotRegistered(teeAddress);
+		}
 
-        if (!registeredTEE.isValid) {
-            revert TEEServiceAlreadyInvalid(teeAddress);
-        }
+		if (!registeredTEE.isValid) {
+			revert TEEServiceAlreadyInvalid(teeAddress);
+		}
 
-        // now we check the attestation, and invalidate the TEE if it's no longer valid.
-        // This will only happen if the DCAP Endorsements associated with the TEE's quote
-        // have been updated
-        (bool success,) = attestationContract.verifyAndAttestOnChain(registeredTEE.rawQuote);
-        if (success) {
-            // if the attestation is still valid, then this function call is a no-op except for
-            // wasting the caller's gas. So we revert here to signal that the TEE is still valid.
-            // Offchain users who want to monitor for potential invalid TEEs can do so by calling
-            // this function and checking for the `TEEIsStillValid` error
-            revert TEEIsStillValid(teeAddress);
-        } else {
-            registeredTEEs[teeAddress].isValid = false;
-            emit TEEServiceInvalidated(teeAddress);
-        }
-    }
+		// now we check the attestation, and invalidate the TEE if it's no longer valid.
+		// This will only happen if the DCAP Endorsements associated with the TEE's quote
+		// have been updated
+		(bool success,) = attestationContract.verifyAndAttestOnChain(registeredTEE.rawQuote);
+		if (success) {
+			// if the attestation is still valid, then this function call is a no-op except for
+			// wasting the caller's gas. So we revert here to signal that the TEE is still valid.
+			// Offchain users who want to monitor for potential invalid TEEs can do so by calling
+			// this function and checking for the `TEEIsStillValid` error
+			revert TEEIsStillValid(teeAddress);
+		} else {
+			registeredTEEs[teeAddress].isValid = false;
+			emit TEEServiceInvalidated(teeAddress);
+		}
+	}
 
-    /**
-     * @notice Returns the TD10ReportBody for the quote used to register a given TEE-controlled address
-     * @param teeAddress The TEE-controlled address to get the TD10ReportBody for
-     * @return reportBody The TD10ReportBody for the given TEE-controlled address
-     * @dev this is useful for when both onchain and offchain users want more
-     * information about the registered TEE
-     */
-    function getReportBody(address teeAddress) public view returns (TD10ReportBody memory) {
-        bytes memory rawQuote = registeredTEEs[teeAddress].rawQuote;
-        require(rawQuote.length > 0, TEEServiceNotRegistered(teeAddress));
-        return QuoteParser.parseV4Quote(rawQuote);
-    }
+	/**
+	 * @notice Returns the TD10ReportBody for the quote used to register a given TEE-controlled address
+	 * @param teeAddress The TEE-controlled address to get the TD10ReportBody for
+	 * @return reportBody The TD10ReportBody for the given TEE-controlled address
+	 * @dev this is useful for when both onchain and offchain users want more
+	 * information about the registered TEE
+	 */
+	function getReportBody(address teeAddress) public view returns (TD10ReportBody memory) {
+		bytes memory rawQuote = registeredTEEs[teeAddress].rawQuote;
+		require(rawQuote.length > 0, TEEServiceNotRegistered(teeAddress));
+		return QuoteParser.parseV4Quote(rawQuote);
+	}
 
-    /**
-     * @notice Computes the digest for the EIP-712 signature
-     * @dev This is useful for when both onchain and offchain users want to compute the digest
-     * for the EIP-712 signature, and then use it to verify the signature
-     * @param structHash The struct hash for the EIP-712 signature
-     * @return The digest for the EIP-712 signature
-     */
-    function hashTypedDataV4(bytes32 structHash) public view returns (bytes32) {
-        return _hashTypedDataV4(structHash);
-    }
+	/**
+	 * @notice Computes the digest for the EIP-712 signature
+	 * @dev This is useful for when both onchain and offchain users want to compute the digest
+	 * for the EIP-712 signature, and then use it to verify the signature
+	 * @param structHash The struct hash for the EIP-712 signature
+	 * @return The digest for the EIP-712 signature
+	 */
+	function hashTypedDataV4(bytes32 structHash) public view returns (bytes32) {
+		return _hashTypedDataV4(structHash);
+	}
 
-    /**
-     * @notice Computes the struct hash for the EIP-712 signature
-     * @dev This is useful for when both onchain and offchain users want to compute the struct hash
-     * for the EIP-712 signature, and then use it to verify the signature
-     * @param rawQuote The raw quote from the TEE device
-     * @param nonce The nonce to use for the EIP-712 signature
-     * @return The struct hash for the EIP-712 signature
-     */
-    function computeStructHash(bytes calldata rawQuote, uint256 nonce) public pure returns (bytes32) {
-        return keccak256(abi.encode(REGISTER_TYPEHASH, keccak256(rawQuote), nonce));
-    }
+	/**
+	 * @notice Computes the struct hash for the EIP-712 signature
+	 * @dev This is useful for when both onchain and offchain users want to compute the struct hash
+	 * for the EIP-712 signature, and then use it to verify the signature
+	 * @param rawQuote The raw quote from the TEE device
+	 * @param nonce The nonce to use for the EIP-712 signature
+	 * @return The struct hash for the EIP-712 signature
+	 */
+	function computeStructHash(bytes calldata rawQuote, uint256 nonce) public pure returns (bytes32) {
+		return keccak256(abi.encode(REGISTER_TYPEHASH, keccak256(rawQuote), nonce));
+	}
 }

--- a/src/interfaces/IFlashtestationRegistry.sol
+++ b/src/interfaces/IFlashtestationRegistry.sol
@@ -11,22 +11,22 @@ import {WorkloadId} from "../utils/QuoteParser.sol";
 interface IFlashtestationRegistry {
     // TEE identity and status tracking
     struct RegisteredTEE {
-        WorkloadId workloadId; // The workloadID of the TEE device
+		TD10ReportBody parsedReportBody; // Parsed form of the quote to avoid parsing
         bytes rawQuote; // The raw quote from the TEE device, which is stored to allow for future quote quote invalidation
+		bytes userData; // The application-specific attested to data
         bool isValid; // true upon first registration, and false after a quote invalidation
-        bytes publicKey; // The 64-byte uncompressed public key of TEE-controlled address, used to encrypt messages to the TEE
     }
 
     // Events
     event TEEServiceRegistered(
-        address teeAddress, WorkloadId workloadId, bytes rawQuote, bytes publicKey, bool alreadyExists
+        address teeAddress, bytes rawQuote /* dev: could be hash of the quote */, bytes userData, bool alreadyExists
     );
     event TEEServiceInvalidated(address teeAddress);
 
     // Errors
     error InvalidQuote(bytes output);
     error ByteSizeExceeded(uint256 size);
-    error TEEServiceAlreadyRegistered(address teeAddress, WorkloadId workloadId);
+    error TEEServiceAlreadyRegistered(address teeAddress, bytes rawQuote /* dev: could be hash of the quote */);
     error SenderMustMatchTEEAddress(address sender, address teeAddress);
     error TEEServiceNotRegistered(address teeAddress);
     error TEEServiceAlreadyInvalid(address teeAddress);

--- a/src/interfaces/IFlashtestationRegistry.sol
+++ b/src/interfaces/IFlashtestationRegistry.sol
@@ -11,9 +11,9 @@ import {WorkloadId} from "../utils/QuoteParser.sol";
 interface IFlashtestationRegistry {
     // TEE identity and status tracking
     struct RegisteredTEE {
-		TD10ReportBody parsedReportBody; // Parsed form of the quote to avoid parsing
+        TD10ReportBody parsedReportBody; // Parsed form of the quote to avoid parsing
         bytes rawQuote; // The raw quote from the TEE device, which is stored to allow for future quote quote invalidation
-		bytes userData; // The application-specific attested to data
+        bytes userData; // The application-specific attested to data
         bool isValid; // true upon first registration, and false after a quote invalidation
     }
 


### PR DESCRIPTION
Working out some ideas in practice. I'll suggest changes to the spec to match before merging.