### PR TITLE
Add commit hash to policy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,9 @@
 [submodule "lib/automata-dcap-attestation"]
 	path = lib/automata-dcap-attestation
 	url = https://github.com/automata-network/automata-dcap-attestation
-[submodule "lib/openzeppelin-contracts-upgradeable"]
-	path = lib/openzeppelin-contracts-upgradeable
-	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable
 [submodule "lib/openzeppelin-foundry-upgrades"]
 	path = lib/openzeppelin-foundry-upgrades
 	url = https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades
+[submodule "lib/openzeppelin-contracts-upgradeable"]
+	path = lib/openzeppelin-contracts-upgradeable
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable

--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ You can find a [specification for the protocol here](https://github.com/flashbot
    b. Verify TEE Quote
 
    c. Extract and store:
-      - TEE address (from reportData[0:20])
-      - Extended registration data for the application to use (keccak of the extended data must match reportData[20:52])
-      - Full parsed report body for cheap access to TD report data fields
-      - Raw quote for future invalidation
+
+   - TEE address (from reportData[0:20])
+   - Extended registration data for the application to use (keccak of the extended data must match reportData[20:52])
+   - Full parsed report body for cheap access to TD report data fields
+   - Raw quote for future invalidation
 
 1. **Verify Flashtestation Transaction**
 
@@ -171,10 +172,19 @@ ADDRESS_BLOCK_BUILDER_POLICY=0x0000000000000000000000000000000000000042
 # this is the workload ID computed from the TEE's measurement registers
 # You can compute this from a registered TEE's report body using BlockBuilderPolicy.workloadIdForTDRegistration
 WORKLOAD_ID=0xeee********************************************************9164e
+
+# this is the commit hash of the source code that was used to build the TEE image
+# identified by the WORKLOAD_ID above
+COMMIT_HASH=1234567890abcdef1234567890abcdef12345678
+
+# a comma-separated list of URLs that point to the source code that was used to build the TEE image identified by the WORKLOAD_ID above
+RECORD_LOCATORS=https://github.com/flashbots/flashbots-images/commit/a5aa6c75fbecc4b88faf4886cbd3cb2c667f4a8c, https://ipfs.io/ipfs/bafybeihkoviema7g3gxyt6la7vd5ho32ictqbilu3wnlo3rs7ewhnp7lly
 ```
 
 Then, to execute, run:
 
 ```
+
 forge script --chain 1301 script/Interactions.s.sol:AddWorkloadToPolicyScript --rpc-url $UNICHAIN_SEPOLIA_RPC_URL --broadcast --verify --interactives 1 -vvvv
+
 ```

--- a/env.sample
+++ b/env.sample
@@ -10,4 +10,6 @@ OWNER_BLOCK_BUILDER_POLICY=0x0000000000000000000000000000000000000042
 
 ADDRESS_BLOCK_BUILDER_POLICY=0x0000000000000000000000000000000000000042
 WORKLOAD_ID=0xeee********************************************************9164e
+COMMIT_HASH=1234567890abcdef1234567890abcdef12345678
+RECORD_LOCATORS=https://github.com/flashbots/flashbots-images/commit/a5aa6c75fbecc4b88faf4886cbd3cb2c667f4a8c, https://ipfs.io/ipfs/bafybeihkoviema7g3gxyt6la7vd5ho32ictqbilu3wnlo3rs7ewhnp7lly
 PATH_TO_ATTESTATION_QUOTE=/some/path/quote.bin

--- a/script/Interactions.s.sol
+++ b/script/Interactions.s.sol
@@ -5,6 +5,7 @@ import {Script, console} from "forge-std/Script.sol";
 import {BlockBuilderPolicy, WorkloadId} from "../src/BlockBuilderPolicy.sol";
 import {FlashtestationRegistry} from "../src/FlashtestationRegistry.sol";
 import {DeploymentUtils} from "./utils/DeploymentUtils.sol";
+import {StringUtils} from "../src/utils/StringUtils.sol";
 
 /// @title AddWorkloadToPolicyScript
 /// @notice A simple helper script to add a workload to the policy
@@ -19,9 +20,22 @@ contract AddWorkloadToPolicyScript is Script {
         console.log("ADDRESS_BLOCK_BUILDER_POLICY:");
         console.logAddress(address(policy));
         bytes32 workloadId = vm.envBytes32("WORKLOAD_ID");
+        string memory commitHash = vm.envString("COMMIT_HASH");
         console.log("WORKLOAD_ID:");
         console.logBytes32(workloadId);
-        policy.addWorkloadToPolicy(WorkloadId.wrap(vm.envBytes32("WORKLOAD_ID")));
+        console.log("COMMIT_HASH:");
+        console.log(commitHash);
+        string memory sourceLocatorsRaw = vm.envString("RECORD_LOCATORS");
+        string[] memory recordLocators = StringUtils.splitCommaSeparated(sourceLocatorsRaw);
+        console.log("RECORD_LOCATORS:");
+        for (uint256 i = 0; i < recordLocators.length; i++) {
+            console.log(recordLocators[i]);
+            if (StringUtils.isEmpty(recordLocators[i])) {
+                revert("one of the RECORD_LOCATORS is empty, make sure to use a comma-separated list of URLs");
+            }
+        }
+
+        policy.addWorkloadToPolicy(WorkloadId.wrap(workloadId), commitHash, recordLocators);
         console.log("WorkloadId added to policy");
         vm.stopBroadcast();
     }

--- a/src/utils/StringUtils.sol
+++ b/src/utils/StringUtils.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+/// @title StringUtils
+/// @notice Utility library for string operations
+library StringUtils {
+    /// @notice Splits a comma-separated string into a string[] array
+    /// @dev Also trims leading and trailing whitespace from each segment
+    /// @param input The input string to split
+    /// @return An array of strings, each representing a segment of the input string
+    function splitCommaSeparated(string memory input) internal pure returns (string[] memory) {
+        bytes memory strBytes = bytes(input);
+        uint256 segments = 1;
+        for (uint256 i = 0; i < strBytes.length; i++) {
+            if (strBytes[i] == ",") {
+                segments++;
+            }
+        }
+        string[] memory parts = new string[](segments);
+        uint256 lastIndex = 0;
+        uint256 partIdx = 0;
+        for (uint256 i = 0; i <= strBytes.length; i++) {
+            if (i == strBytes.length || strBytes[i] == ",") {
+                // Trim leading/trailing whitespace
+                uint256 start = lastIndex;
+                uint256 end = i;
+                // Trim leading spaces
+                while (start < end && strBytes[start] == " ") {
+                    start++;
+                }
+                // Trim trailing spaces
+                while (end > start && strBytes[end - 1] == " ") {
+                    end--;
+                }
+                bytes memory part = new bytes(end - start);
+                for (uint256 j = 0; j < end - start; j++) {
+                    part[j] = strBytes[start + j];
+                }
+                parts[partIdx] = string(part);
+                partIdx++;
+                lastIndex = i + 1;
+            }
+        }
+        return parts;
+    }
+
+    /// @notice Checks if a string is empty
+    /// @param str The string to check
+    /// @return True if the string is empty, false otherwise
+    function isEmpty(string memory str) internal pure returns (bool) {
+        return bytes(str).length == 0;
+    }
+}

--- a/test/StringUtils.t.sol
+++ b/test/StringUtils.t.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import "forge-std/Test.sol";
+import "../src/utils/StringUtils.sol";
+
+contract StringUtilsTest is Test {
+    function test_splitCommaSeparated_singleURL() public {
+        string memory input =
+            "https://github.com/flashbots/flashbots-images/commit/a5aa6c75fbecc4b88faf4886cbd3cb2c667f4a8c";
+        string[] memory result = StringUtils.splitCommaSeparated(input);
+        assertEq(result.length, 1, "Should return one element");
+        assertEq(
+            result[0],
+            "https://github.com/flashbots/flashbots-images/commit/a5aa6c75fbecc4b88faf4886cbd3cb2c667f4a8c",
+            "Element should match input URL"
+        );
+    }
+
+    function test_splitCommaSeparated_multipleURLs() public {
+        string memory input =
+            "https://github.com/flashbots/mev-boost/commit/7fb1e6f8f96b55c0f672b0b66b61e7f10e1b6e8a,https://ipfs.io/ipfs/bafybeihkoviema7g3gxyt6la7vd5ho32ictqbilu3wnlo3rs7ewhnp7lly";
+        string[] memory result = StringUtils.splitCommaSeparated(input);
+        assertEq(result.length, 2, "Should return two elements");
+        assertEq(
+            result[0],
+            "https://github.com/flashbots/mev-boost/commit/7fb1e6f8f96b55c0f672b0b66b61e7f10e1b6e8a",
+            "First element should be first URL"
+        );
+        assertEq(
+            result[1],
+            "https://ipfs.io/ipfs/bafybeihkoviema7g3gxyt6la7vd5ho32ictqbilu3wnlo3rs7ewhnp7lly",
+            "Second element should be second URL"
+        );
+    }
+
+    function test_splitCommaSeparated_trimsWhitespaceURLs() public {
+        string memory input =
+            "  https://github.com/ethereum/go-ethereum/commit/9bbb9df18529f495f1312e94db22ddcf3e3022f8 , https://github.com/flashbots/builder/commit/d8e2d3e5f8ad7f8dd8e99e7e023e8e5e4bbbc8fb  ,https://ipfs.io/ipfs/bafkreigjpewirtzmt2ggqx7zqd5g5eqrtcnfli5oobqp7w3s2tagtusomy ";
+        string[] memory result = StringUtils.splitCommaSeparated(input);
+        assertEq(result.length, 3, "Should return three elements");
+        assertEq(
+            result[0],
+            "https://github.com/ethereum/go-ethereum/commit/9bbb9df18529f495f1312e94db22ddcf3e3022f8",
+            "First element should be trimmed URL"
+        );
+        assertEq(
+            result[1],
+            "https://github.com/flashbots/builder/commit/d8e2d3e5f8ad7f8dd8e99e7e023e8e5e4bbbc8fb",
+            "Second element should be trimmed URL"
+        );
+        assertEq(
+            result[2],
+            "https://ipfs.io/ipfs/bafkreigjpewirtzmt2ggqx7zqd5g5eqrtcnfli5oobqp7w3s2tagtusomy",
+            "Third element should be trimmed URL"
+        );
+    }
+
+    function test_splitCommaSeparated_emptyString() public {
+        string memory input = "";
+        string[] memory result = StringUtils.splitCommaSeparated(input);
+        assertEq(result.length, 1, "Should return one element for empty string");
+        assertEq(result[0], "", "Element should be empty string");
+    }
+
+    function test_splitCommaSeparated_leadingAndTrailingCommasURLs() public {
+        string memory input =
+            ",https://github.com/flashbots/rbuilder/commit/c2e3d7c5f8ad7f8dd8e99e7e023e8e5e4bbbc8fb,https://ipfs.io/ipfs/bafybeif7l5k6vk6kpnfsc3biswihqz3le5ngnf47mj3lzrjbdh6jmqnzyi,";
+        string[] memory result = StringUtils.splitCommaSeparated(input);
+        assertEq(result.length, 4, "Should return four elements");
+        assertEq(result[0], "", "First element should be empty");
+        assertEq(
+            result[1],
+            "https://github.com/flashbots/rbuilder/commit/c2e3d7c5f8ad7f8dd8e99e7e023e8e5e4bbbc8fb",
+            "Second element should be first URL"
+        );
+        assertEq(
+            result[2],
+            "https://ipfs.io/ipfs/bafybeif7l5k6vk6kpnfsc3biswihqz3le5ngnf47mj3lzrjbdh6jmqnzyi",
+            "Third element should be second URL"
+        );
+        assertEq(result[3], "", "Fourth element should be empty");
+    }
+
+    function test_splitCommaSeparated_onlyCommas() public {
+        string memory input = ",,,";
+        string[] memory result = StringUtils.splitCommaSeparated(input);
+        assertEq(result.length, 4, "Should return four empty elements");
+        for (uint256 i = 0; i < result.length; i++) {
+            assertEq(result[i], "", "Each element should be empty string");
+        }
+    }
+
+    function test_splitCommaSeparated_spacesOnly() public {
+        string memory input = "   ,  , ";
+        string[] memory result = StringUtils.splitCommaSeparated(input);
+        assertEq(result.length, 3, "Should return three elements");
+        for (uint256 i = 0; i < result.length; i++) {
+            assertEq(result[i], "", "Each element should be empty string after trimming");
+        }
+    }
+
+    function test_splitCommaSeparated_variousURLs() public {
+        string memory input =
+            "https://github.com/flashbots/rollup-boost/commit/a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0, https://github.com/paradigmxyz/reth/commit/b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0 ,https://ipfs.io/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi";
+        string[] memory result = StringUtils.splitCommaSeparated(input);
+        assertEq(result.length, 3, "Should return three elements");
+        assertEq(
+            result[0],
+            "https://github.com/flashbots/rollup-boost/commit/a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+            "First element should be first URL"
+        );
+        assertEq(
+            result[1],
+            "https://github.com/paradigmxyz/reth/commit/b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0",
+            "Second element should be second URL"
+        );
+        assertEq(
+            result[2],
+            "https://ipfs.io/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+            "Third element should be third URL"
+        );
+    }
+
+    function test_splitCommaSeparated_URLsWithQueryStrings() public {
+        string memory input =
+            "https://github.com/flashbots/mev-boost-relay/commit/e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0?ref=main, https://ipfs.io/ipfs/bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq?filename=wiki.html";
+        string[] memory result = StringUtils.splitCommaSeparated(input);
+        assertEq(result.length, 2, "Should return two elements");
+        assertEq(
+            result[0],
+            "https://github.com/flashbots/mev-boost-relay/commit/e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0?ref=main",
+            "First element should be first URL with query"
+        );
+        assertEq(
+            result[1],
+            "https://ipfs.io/ipfs/bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq?filename=wiki.html",
+            "Second element should be second URL with query"
+        );
+    }
+}


### PR DESCRIPTION
We want to add the commit hash to the Policy because Flashtestations
needs a way to associate a TEE's workloadId with the source code used
to build the TEE image represented by that workloadId. There is no way
to do this that does not involve some sort of onchain permissioned action,
because to do it without permissioned action would require building TEE
images onchain, which is prohibitively expensive. Instead, we settle for
a multisig signer that is permissioned to associate workloadIds with commit hashes.

Offchain verifiers can then use this commit hash to locate the TEE image build source code,
build the TEE image, derive the workloadId, and then compare that locally-built
workloadId with the workloadId in the policy that is associated with the commit hash.
In this way, anyone can reliably prove that a given block is built using source code
that orders transactions in a fair and verifiable manner which is the purpose of flashtestations).