### PR TITLE
L-01 add zero-address checks on all contracts

### DIFF
--- a/src/BlockBuilderPolicy.sol
+++ b/src/BlockBuilderPolicy.sol
@@ -80,6 +80,7 @@ contract BlockBuilderPolicy is Initializable, UUPSUpgradeable, OwnableUpgradeabl
 
     // ============ Errors ============
 
+    error InvalidRegistry();
     error WorkloadAlreadyInPolicy();
     error WorkloadNotInPolicy();
     error UnauthorizedBlockBuilder(address caller); // the teeAddress is not associated with a valid TEE workload
@@ -115,6 +116,8 @@ contract BlockBuilderPolicy is Initializable, UUPSUpgradeable, OwnableUpgradeabl
     function initialize(address _initialOwner, address _registry) external initializer {
         __Ownable_init(_initialOwner);
         __EIP712_init("BlockBuilderPolicy", "1");
+        require(_registry != address(0), InvalidRegistry());
+
         registry = _registry;
         emit RegistrySet(_registry);
     }

--- a/src/FlashtestationRegistry.sol
+++ b/src/FlashtestationRegistry.sol
@@ -65,6 +65,7 @@ contract FlashtestationRegistry is
     function initialize(address owner, address _attestationContract) external initializer {
         __Ownable_init(owner);
         __EIP712_init("FlashtestationRegistry", "1");
+        require(_attestationContract != address(0), InvalidAttestationContract());
         attestationContract = IAttestation(_attestationContract);
     }
 

--- a/src/interfaces/IFlashtestationRegistry.sol
+++ b/src/interfaces/IFlashtestationRegistry.sol
@@ -22,6 +22,7 @@ interface IFlashtestationRegistry {
     event TEEServiceInvalidated(address teeAddress);
 
     // Errors
+    error InvalidAttestationContract();
     error InvalidQuote(bytes output);
     error InvalidReportDataLength(uint256 length);
     error InvalidRegistrationDataHash(bytes32 expected, bytes32 received);

--- a/test/FlashtestationRegistry.t.sol
+++ b/test/FlashtestationRegistry.t.sol
@@ -144,6 +144,14 @@ contract FlashtestationRegistryTest is Test {
         registry.registerTEEService(mockQuote, mockf200.extData);
     }
 
+    function test_reverts_with_invalid_attestation_contract() public {
+        address implementation = address(new FlashtestationRegistry());
+        vm.expectRevert(IFlashtestationRegistry.InvalidAttestationContract.selector);
+        UnsafeUpgrades.deployUUPSProxy(
+            implementation, abi.encodeCall(FlashtestationRegistry.initialize, (owner, address(0x0)))
+        );
+    }
+
     function test_reverts_with_registering_same_quote_twice() public {
         bytes memory mockOutput = mockf200.output;
         bytes memory mockQuote = mockf200.quote;


### PR DESCRIPTION
This addresses L-01 on the Q3 2025 OZ audit:

When operations with address parameters are performed, it is crucial to ensure that the address is not set to zero. Setting an address to zero is problematic because it has special burn/renounce semantics. This action should be handled by a separate function to prevent accidental loss of access during value or ownership transfers.

Throughout the codebase, multiple instances of missing zero-address checks were identified: • The _registry function in the BlockBuilderPolicy contract • The _attestationContract function in the FlashtestationRegistry contract

Consider always performing a zero-address check before assigning a state variable.