### PR TITLE
Fix L-05 no checks on sourceLocators array

### DIFF
--- a/src/BlockBuilderPolicy.sol
+++ b/src/BlockBuilderPolicy.sol
@@ -85,7 +85,8 @@ contract BlockBuilderPolicy is Initializable, UUPSUpgradeable, OwnableUpgradeabl
     error WorkloadNotInPolicy();
     error UnauthorizedBlockBuilder(address caller); // the teeAddress is not associated with a valid TEE workload
     error InvalidNonce(uint256 expected, uint256 provided);
-    error CommitHashLengthError(uint256 length);
+    error EmptyCommitHash();
+    error EmptySourceLocators();
 
     // ============ Events ============
 
@@ -276,7 +277,8 @@ contract BlockBuilderPolicy is Initializable, UUPSUpgradeable, OwnableUpgradeabl
         external
         onlyOwner
     {
-        require(bytes(commitHash).length > 0, CommitHashLengthError(bytes(commitHash).length));
+        require(bytes(commitHash).length > 0, EmptyCommitHash());
+        require(sourceLocators.length > 0, EmptySourceLocators());
 
         bytes32 workloadKey = WorkloadId.unwrap(workloadId);
 

--- a/test/BlockBuilderPolicy.t.sol
+++ b/test/BlockBuilderPolicy.t.sol
@@ -188,6 +188,16 @@ contract BlockBuilderPolicyTest is Test {
         policy.addWorkloadToPolicy(mockf200.workloadId, mockf200.commitHash, mockf200.sourceLocators);
     }
 
+    function test_addWorkloadToPolicy_reverts_if_empty_commit_hash() public {
+        vm.expectRevert(abi.encodeWithSelector(BlockBuilderPolicy.EmptyCommitHash.selector, 0));
+        policy.addWorkloadToPolicy(mockf200.workloadId, "", mockf200.sourceLocators);
+    }
+
+    function test_addWorkloadToPolicy_reverts_if_empty_source_locators() public {
+        vm.expectRevert(abi.encodeWithSelector(BlockBuilderPolicy.EmptySourceLocators.selector, 0));
+        policy.addWorkloadToPolicy(mockf200.workloadId, mockf200.commitHash, new string[](0));
+    }
+
     function test_addWorkloadToPolicy_reverts_if_not_owner() public {
         vm.prank(address(0x123));
         vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, address(0x123)));


### PR DESCRIPTION
This fixes L-05 on the Q3 2025 OZ audit.

When a new workload is added to a policy, the governance has to provide the commitHash and sourceLocators to save the metadata for the workload. The commitHash is the commit hash of the git repository whose source code is used to build the TEE image identified by the workloadId, and the sourceLocators is an array of URIs pointing to that source code. The commitHash cannot be empty because the length must be greater than 0, but sourceLocators has no checks. This array should have at least one element to fetch the source code.

Consider ensuring that the sourceLocators array has at least one element.