### PR TITLE
L-02 add missing deadline protection on FlashtestationRegistry:permit…

### DIFF
--- a/src/interfaces/IFlashtestationRegistry.sol
+++ b/src/interfaces/IFlashtestationRegistry.sol
@@ -23,6 +23,7 @@ interface IFlashtestationRegistry {
 
     // Errors
     error InvalidAttestationContract();
+    error ExpiredSignature(uint256 deadline);
     error InvalidQuote(bytes output);
     error InvalidReportDataLength(uint256 length);
     error InvalidRegistrationDataHash(bytes32 expected, bytes32 received);

--- a/test/FlashtestationRegistryFeeTests.t.sol
+++ b/test/FlashtestationRegistryFeeTests.t.sol
@@ -109,7 +109,7 @@ contract FlashtestationRegistryFeeTest is Test {
         attestationContract.setQuoteResult(mockQuote, true, mockOutput);
 
         uint256 nonce = registry.nonces(expectedAddress);
-        bytes32 structHash = registry.computeStructHash(mockQuote, mock46f6.extData, nonce);
+        bytes32 structHash = registry.computeStructHash(mockQuote, mock46f6.extData, nonce, block.timestamp);
         bytes32 digest = registry.hashTypedDataV4(structHash);
 
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
@@ -120,7 +120,9 @@ contract FlashtestationRegistryFeeTest is Test {
         vm.expectEmit(address(registry));
         emit IFlashtestationRegistry.TEEServiceRegistered(expectedAddress, mockQuote, false);
 
-        registry.permitRegisterTEEService{value: TEST_FEE}(mockQuote, mock46f6.extData, nonce, signature);
+        registry.permitRegisterTEEService{value: TEST_FEE}(
+            mockQuote, mock46f6.extData, nonce, block.timestamp, signature
+        );
 
         // Verify registration succeeded
         (bool isValid, IFlashtestationRegistry.RegisteredTEE memory registration) =
@@ -186,7 +188,7 @@ contract FlashtestationRegistryFeeTest is Test {
         attestationContract.setQuoteResult(mockQuote, true, mockOutput);
 
         uint256 nonce = registry.nonces(expectedAddress);
-        bytes32 structHash = registry.computeStructHash(mockQuote, mock46f6.extData, nonce);
+        bytes32 structHash = registry.computeStructHash(mockQuote, mock46f6.extData, nonce, block.timestamp);
         bytes32 digest = registry.hashTypedDataV4(structHash);
 
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
@@ -197,7 +199,9 @@ contract FlashtestationRegistryFeeTest is Test {
         vm.expectRevert(
             abi.encodeWithSelector(MockAutomataDcapAttestationFee.InsufficientFee.selector, TEST_FEE, TEST_FEE - 1)
         );
-        registry.permitRegisterTEEService{value: TEST_FEE - 1}(mockQuote, mock46f6.extData, nonce, signature);
+        registry.permitRegisterTEEService{value: TEST_FEE - 1}(
+            mockQuote, mock46f6.extData, nonce, block.timestamp, signature
+        );
     }
 
     function test_invalidateAttestation_insufficientFee() public {


### PR DESCRIPTION
…RegisterTEEService

This addresses L-02 of the Q3 2025 OZ audit:

When constraining permit signatures, it is highly recommended to have a deadline protection in case a signature is not executed within a specific time window set by the signer. Throughout the codebase, multiple instances of missing deadline protection for signatures were identified:

• In FlashtestationRegistry.sol, the permitRegisterTEEService function • In BlockBuilderPolicy.sol, the permitVerifyBlockBuilderProof function

Consider checking that the provided deadline is not expired and is part of the EIP-712 digest hash.

Note: we do not add a deadline for BlockBuilderPolicy's permitVerifyBlockBuilderProof, because the high frequency with which we'll be broadcasting new calls to permitVerifyBlockBuilderProof which invalidate the old calls makes a deadline not very useful for it. We intend to broadcast 1 such call every 200ms, for each flashblock. In fact, we can't even correctly implement a deadline for permitVerifyBlockBuilderProof, because the smallest granularity we could use for the deadline is 1 second, and that is not enough time to specify multiple flashblocks (which we'll need to do).