### PR TITLE
L-03 added invalidatePreviousSignature function

### DIFF
--- a/src/FlashtestationRegistry.sol
+++ b/src/FlashtestationRegistry.sol
@@ -291,6 +291,22 @@ contract FlashtestationRegistry is
     }
 
     /**
+     * @notice Allows a user to increment their EIP-712 signature nonce, invalidating any previously signed but unexecuted permit signatures.
+     * @dev This function provides a way for users to proactively invalidate old signatures by incrementing their nonce,
+     * without needing to execute a valid permit.
+     * This is particularly useful if a user suspects a signature may have been compromised or simply wants to ensure
+     * that any outstanding, unused signatures with the current nonce can no longer be executed.
+     * @dev The function requires the provided nonce to match the user's current nonce, as a defense against the caller
+     * mistakenly invalidating a nonce that they did not intend to invalidate
+     * @param _nonce The expected current nonce for the caller; must match the stored nonce
+     */
+    function invalidatePreviousSignature(uint256 _nonce) external {
+        require(_nonce == nonces[msg.sender], InvalidNonce(nonces[msg.sender], _nonce));
+        nonces[msg.sender]++;
+        emit PreviousSignatureInvalidated(msg.sender, _nonce);
+    }
+
+    /**
      * @notice Computes the digest for the EIP-712 signature
      * @dev This is useful for when both onchain and offchain users want to compute the digest
      * for the EIP-712 signature, and then use it to verify the signature

--- a/src/interfaces/IFlashtestationRegistry.sol
+++ b/src/interfaces/IFlashtestationRegistry.sol
@@ -20,6 +20,7 @@ interface IFlashtestationRegistry {
     // Events
     event TEEServiceRegistered(address teeAddress, bytes rawQuote, bool alreadyExists);
     event TEEServiceInvalidated(address teeAddress);
+    event PreviousSignatureInvalidated(address teeAddress, uint256 invalidatedNonce);
 
     // Errors
     error InvalidAttestationContract();


### PR DESCRIPTION
This addresses L-03 of the Q3 2025 OZ audit:

When a user signs a permit digest with a specific nonce but later wants to invalidate previous signatures, the most used implementations are either a function to increment the nonce or executing a no-op operation. In the case of FlashtestationRegistry, neither of these two options is available. No-op permit executions are reverted in order to avoid gas costs. Thus, the only way to increment the nonce is by executing a valid signature with a different valid rawQuote value.

Consider adding a function to increment the nonce of the caller in order to invalidate previous signatures not yet executed.