### PR TITLE
L-06 add external function for EIP-712 domain separators

### DIFF
--- a/src/BlockBuilderPolicy.sol
+++ b/src/BlockBuilderPolicy.sol
@@ -395,4 +395,14 @@ contract BlockBuilderPolicy is Initializable, UUPSUpgradeable, OwnableUpgradeabl
     function computeStructHash(uint8 version, bytes32 blockContentHash, uint256 nonce) public pure returns (bytes32) {
         return keccak256(abi.encode(VERIFY_BLOCK_BUILDER_PROOF_TYPEHASH, version, blockContentHash, nonce));
     }
+
+    /**
+     * @notice Returns the domain separator for the EIP-712 signature
+     * @dev This is useful for when both onchain and offchain users want to compute the domain separator
+     * for the EIP-712 signature, and then use it to verify the signature
+     * @return The domain separator for the EIP-712 signature
+     */
+    function domainSeparator() external view returns (bytes32) {
+        return _domainSeparatorV4();
+    }
 }

--- a/src/FlashtestationRegistry.sol
+++ b/src/FlashtestationRegistry.sol
@@ -354,4 +354,14 @@ contract FlashtestationRegistry is
             abi.encode(REGISTER_TYPEHASH, keccak256(rawQuote), keccak256(extendedRegistrationData), nonce, deadline)
         );
     }
+
+    /**
+     * @notice Returns the domain separator for the EIP-712 signature
+     * @dev This is useful for when both onchain and offchain users want to compute the domain separator
+     * for the EIP-712 signature, and then use it to verify the signature
+     * @return The domain separator for the EIP-712 signature
+     */
+    function domainSeparator() external view returns (bytes32) {
+        return _domainSeparatorV4();
+    }
 }


### PR DESCRIPTION
This addresses L-06 of the Q3 2025 OZ audit:\
\
The domain separator, as defined in EIP-712, is used for obtaining the final message hash signed by the user. The BlockBuilderPolicy and FlashtestationRegistry contracts use EIP-712 typed data but do not expose their domain separator via a public view function. As such, off-chain signers and integrators must reconstruct the domain, which can be error-prone.

Consider exposing the domain separator via a public function to allow for the easy fetching of the domain separator.