### PR TITLE
N-01 incomplete docstring

### DIFF
--- a/src/interfaces/IAttestation.sol
+++ b/src/interfaces/IAttestation.sol
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
+/**
+ * @title IAttestation
+ * @dev Interface for the Automata DCAPattestation contract, which verifies TEE quotes
+ */
 interface IAttestation {
     function verifyAndAttestOnChain(bytes calldata rawQuote) external payable returns (bool, bytes memory);
 }


### PR DESCRIPTION
This completes N-01 of the Q3 2025 OZ audit:

In the initialize function of the FlashtestationRegistry contract, the owner parameter is not documented.

Consider thoroughly documenting all functions/events (and their parameters or return values) that are part of a contract's public API. When writing docstrings, consider following the Ethereum Natural Specification Format (NatSpec).