### PR TITLE
N-06 add missing named parameters in mappings

### DIFF
--- a/src/BlockBuilderPolicy.sol
+++ b/src/BlockBuilderPolicy.sol
@@ -70,17 +70,17 @@ contract BlockBuilderPolicy is
     /// Adding and removing a workload is O(1).
     /// This means the critical `_cachedIsAllowedPolicy` function is O(1) since we can directly check if a workloadId exists
     /// in the mapping
-    mapping(bytes32 => WorkloadMetadata) private approvedWorkloads;
+    mapping(bytes32 workloadId => WorkloadMetadata) private approvedWorkloads;
 
     /// @inheritdoc IBlockBuilderPolicy
     address public registry;
 
     /// @inheritdoc IBlockBuilderPolicy
-    mapping(address => uint256) public nonces;
+    mapping(address teeAddress => uint256 permitNonce) public nonces;
 
     /// @notice Cache of computed workloadIds to avoid expensive recomputation
     /// @dev Maps teeAddress to cached workload information for gas optimization
-    mapping(address => CachedWorkload) private cachedWorkloads;
+    mapping(address teeAddress => CachedWorkload) private cachedWorkloads;
 
     /// @dev Storage gap to allow for future storage variable additions in upgrades
     /// @dev This reserves 46 storage slots (out of 50 total - 4 used for approvedWorkloads, registry, nonces, and cachedWorkloads)

--- a/src/FlashtestationRegistry.sol
+++ b/src/FlashtestationRegistry.sol
@@ -51,10 +51,10 @@ contract FlashtestationRegistry is
      * @notice Returns the registered TEE for a given address
      * @dev This is used to get the registered TEE for a given address
      */
-    mapping(address => RegisteredTEE) public registeredTEEs;
+    mapping(address teeAddress => RegisteredTEE) public registeredTEEs;
 
     /// @inheritdoc IFlashtestationRegistry
-    mapping(address => uint256) public override nonces;
+    mapping(address teeAddress => uint256 permitNonce) public override nonces;
 
     /// @dev Storage gap to allow for future storage variable additions in upgrades
     /// @dev This reserves 47 storage slots (out of 50 total - 3 used for attestationContract, registeredTEEs and nonces)


### PR DESCRIPTION
This addresses N-06 from the Q3 2025 OZ audit

Since Solidity 0.8.18, mappings can include named parameters to provide more clarity about their purpose. Named parameters allow mappings to be declared in the form mapping(KeyType KeyName? => ValueType ValueName?). This feature enhances code readability and maintainability.

Throughout the codebase, multiple instances of mappings without named parameters were identified:

The approvedWorkloads state variable in the BlockBuilderPolicy contract. The nonces state variable in the BlockBuilderPolicy contract. The registeredTEEs state variable in the FlashtestationRegistry contract. The nonces state variable in the FlashtestationRegistry contract. The cachedWorkloads state variable in the BlockBuilderPolicy contract. Consider adding named parameters to mappings in order to improve the readability and maintainability of the codebase.