### PR TITLE
N-12 use ReentrancyGuardTransientUpgradeable for reentrancy guard

### DIFF
--- a/src/FlashtestationRegistry.sol
+++ b/src/FlashtestationRegistry.sol
@@ -5,7 +5,8 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import {ReentrancyGuardTransient} from "@openzeppelin/contracts/utils/ReentrancyGuardTransient.sol";
+import {ReentrancyGuardTransientUpgradeable} from
+    "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardTransientUpgradeable.sol";
 import {EIP712Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
 import {IAttestation} from "./interfaces/IAttestation.sol";
 import {IFlashtestationRegistry} from "./interfaces/IFlashtestationRegistry.sol";
@@ -23,7 +24,7 @@ contract FlashtestationRegistry is
     UUPSUpgradeable,
     OwnableUpgradeable,
     EIP712Upgradeable,
-    ReentrancyGuardTransient
+    ReentrancyGuardTransientUpgradeable
 {
     using ECDSA for bytes32;
 
@@ -64,6 +65,7 @@ contract FlashtestationRegistry is
     function initialize(address owner, address _attestationContract) external override initializer {
         __Ownable_init(owner);
         __EIP712_init("FlashtestationRegistry", "1");
+        __ReentrancyGuardTransient_init();
         require(_attestationContract != address(0), InvalidAttestationContract());
         attestationContract = IAttestation(_attestationContract);
     }


### PR DESCRIPTION
This commit addresses the N-12 of the Q3 2025 OZ audit

The ReentrancyGuardTransientUpgradeable module should be used instead of ReentrancyGuardTransient, as it ensures that all modules remain upgradeable. Although both versions function identically, transitioning to the upgradeable version aligns with best practices for upgradeable contract architectures.

Consider using the ReentrancyGuardTransientUpgradeable module instead of the ReentrancyGuardTransient module and ensuring that all inherited upgradeable module initializers are called within the initialize function, such as __UUPSUpgradeable_init() for UUPS support and __ReentrancyGuardTransient_init() for the reentrancy guard. Doing so will help improve the maintainability and upgradeability of the contract.