### PR TITLE
N-13 improve doRegister function naming

### DIFF
--- a/src/FlashtestationRegistry.sol
+++ b/src/FlashtestationRegistry.sol
@@ -131,11 +131,11 @@ contract FlashtestationRegistry is
      * @notice Verifies + Registers a TEE workload with a specific TEE-controlled address in the FlashtestationRegistry
      * @dev In order to mitigate DoS attacks, the quote must be less than 20KB
      * @dev This is a costly operation (5 million gas) and should be used sparingly.
-     * @param caller The address from which registration request originates, must match the one in the quote
+     * @param signer The address from which registration request originates, must match the one in the quote
      * @param rawQuote The raw quote from the TEE device. Must be a V4 TDX quote
      * @param extendedRegistrationData Abi-encoded application specific attested data
      */
-    function doRegister(address caller, bytes calldata rawQuote, bytes calldata extendedRegistrationData)
+    function doRegister(address signer, bytes calldata rawQuote, bytes calldata extendedRegistrationData)
         internal
         limitBytesSize(rawQuote)
         limitBytesSize(extendedRegistrationData)
@@ -158,8 +158,8 @@ contract FlashtestationRegistry is
 
         // Ensure that the caller is the TEE-controlled address, otherwise we have no guarantees that
         // the TEE-controlled address is the one that is registering the TEE
-        if (caller != teeAddress) {
-            revert SenderMustMatchTEEAddress(caller, teeAddress);
+        if (signer != teeAddress) {
+            revert SignerMustMatchTEEAddress(signer, teeAddress);
         }
 
         // Verify that the extended registration data matches the hash in the TDX report data

--- a/src/interfaces/IFlashtestationRegistry.sol
+++ b/src/interfaces/IFlashtestationRegistry.sol
@@ -50,8 +50,8 @@ interface IFlashtestationRegistry {
     error ByteSizeExceeded(uint256 size);
     /// @notice Emitted when the TEE service is already registered when registering
     error TEEServiceAlreadyRegistered(address teeAddress);
-    /// @notice Emitted when the sender must match the TEE address
-    error SenderMustMatchTEEAddress(address sender, address teeAddress);
+    /// @notice Emitted when the signer doesn't match the TEE address
+    error SignerMustMatchTEEAddress(address signer, address teeAddress);
     /// @notice Emitted when the TEE service is not registered
     error TEEServiceNotRegistered(address teeAddress);
     /// @notice Emitted when the TEE service is already invalid when trying to invalidate a TEE registration

--- a/test/FlashtestationRegistry.t.sol
+++ b/test/FlashtestationRegistry.t.sol
@@ -216,7 +216,7 @@ contract FlashtestationRegistryTest is Test {
         vm.prank(differentAddress);
         vm.expectRevert(
             abi.encodeWithSelector(
-                IFlashtestationRegistry.SenderMustMatchTEEAddress.selector, differentAddress, expectedAddress
+                IFlashtestationRegistry.SignerMustMatchTEEAddress.selector, differentAddress, expectedAddress
             )
         );
         registry.registerTEEService(mockQuote, mockf200.extData);


### PR DESCRIPTION
This addresses N-13 of the Q3 2025 OZ audit.

Though here, I don't use their suggestion teeAddress because it conflicts with another variable, so instead I use signer since in both cases of permitRegisterTEEService and registerTEEService that address is the one who provides the signature