### PR TITLE
N-09 remove blockNumber arg from BlockBuilderProofVerified event

### DIFF
--- a/src/BlockBuilderPolicy.sol
+++ b/src/BlockBuilderPolicy.sol
@@ -148,7 +148,7 @@ contract BlockBuilderPolicy is
 
         bytes32 workloadKey = WorkloadId.unwrap(workloadId);
         string memory commitHash = approvedWorkloads[workloadKey].commitHash;
-        emit BlockBuilderProofVerified(teeAddress, workloadKey, block.number, version, blockContentHash, commitHash);
+        emit BlockBuilderProofVerified(teeAddress, workloadKey, version, blockContentHash, commitHash);
     }
 
     /// @inheritdoc IBlockBuilderPolicy

--- a/src/interfaces/IBlockBuilderPolicy.sol
+++ b/src/interfaces/IBlockBuilderPolicy.sol
@@ -41,17 +41,11 @@ interface IBlockBuilderPolicy {
     /// @notice Emitted when a block builder proof is successfully verified
     /// @param caller The address that called the verification function (TEE address)
     /// @param workloadId The workload identifier of the TEE
-    /// @param blockNumber The block number when the verification occurred
     /// @param version The flashtestation protocol version used
     /// @param blockContentHash The hash of the block content
     /// @param commitHash The git commit hash associated with the workload
     event BlockBuilderProofVerified(
-        address caller,
-        bytes32 workloadId,
-        uint256 blockNumber,
-        uint8 version,
-        bytes32 blockContentHash,
-        string commitHash
+        address caller, bytes32 workloadId, uint8 version, bytes32 blockContentHash, string commitHash
     );
 
     // ============ Errors ============

--- a/test/BlockBuilderPolicy.t.sol
+++ b/test/BlockBuilderPolicy.t.sol
@@ -464,12 +464,7 @@ contract BlockBuilderPolicyTest is Test {
         bytes32 blockContentHash = bytes32(hex"1234");
         vm.expectEmit(address(policy));
         emit IBlockBuilderPolicy.BlockBuilderProofVerified(
-            mockf200.teeAddress,
-            WorkloadId.unwrap(actualWorkloadId),
-            block.number,
-            1,
-            blockContentHash,
-            mockf200.commitHash
+            mockf200.teeAddress, WorkloadId.unwrap(actualWorkloadId), 1, blockContentHash, mockf200.commitHash
         );
 
         vm.prank(mockf200.teeAddress);
@@ -517,12 +512,7 @@ contract BlockBuilderPolicyTest is Test {
         // Expect the event to be emitted
         vm.expectEmit(address(policy));
         emit IBlockBuilderPolicy.BlockBuilderProofVerified(
-            teeAddress,
-            WorkloadId.unwrap(actualWorkloadId),
-            block.number,
-            version,
-            blockContentHash,
-            mock46f6.commitHash
+            teeAddress, WorkloadId.unwrap(actualWorkloadId), version, blockContentHash, mock46f6.commitHash
         );
 
         // Call the function
@@ -553,12 +543,7 @@ contract BlockBuilderPolicyTest is Test {
         // Expect the event to be emitted
         vm.expectEmit(address(policy));
         emit IBlockBuilderPolicy.BlockBuilderProofVerified(
-            teeAddress,
-            WorkloadId.unwrap(actualWorkloadId),
-            block.number,
-            version,
-            blockContentHash,
-            mock46f6.commitHash
+            teeAddress, WorkloadId.unwrap(actualWorkloadId), version, blockContentHash, mock46f6.commitHash
         );
 
         // Call the function
@@ -577,12 +562,7 @@ contract BlockBuilderPolicyTest is Test {
         // Expect the event to be emitted
         vm.expectEmit(address(policy));
         emit IBlockBuilderPolicy.BlockBuilderProofVerified(
-            teeAddress,
-            WorkloadId.unwrap(actualWorkloadId),
-            block.number,
-            version,
-            blockContentHash,
-            mock46f6.commitHash
+            teeAddress, WorkloadId.unwrap(actualWorkloadId), version, blockContentHash, mock46f6.commitHash
         );
 
         // Call the function


### PR DESCRIPTION
This addresses N-09 from the Q3 2025 OZ audit:

In BlockBuilderPolicy.sol, the emit BlockBuilderProofVerified(teeAddress, workloadId, block.number, version, blockContentHash, commitHash); event emission includes unnecessary data fields such as block.number.

To improve the efficiency of the contract, consider removing unnecessary data fields from the event emission such as block.number or block.timestamp since they are already included in the block information.