### PR TITLE
N-03 use custom errors everywhere

### DIFF
--- a/src/utils/QuoteParser.sol
+++ b/src/utils/QuoteParser.sol
@@ -107,9 +107,7 @@ library QuoteParser {
      */
     function checkTEEVersion(bytes memory rawReportBody) internal pure {
         uint16 version = uint16(bytes2((rawReportBody.substring(0, 2)))); // uint16 is 2 bytes
-        if (version != ACCEPTED_TDX_VERSION) {
-            revert InvalidTEEVersion(version);
-        }
+        require(version == ACCEPTED_TDX_VERSION, InvalidTEEVersion(version));
     }
 
     /**
@@ -119,8 +117,6 @@ library QuoteParser {
      */
     function checkTEEType(bytes memory rawReportBody) internal pure {
         bytes4 teeType = bytes4(rawReportBody.substring(2, 4)); // 4 bytes
-        if (teeType != TDX_TEE) {
-            revert InvalidTEEType(teeType);
-        }
+        require(teeType == TDX_TEE, InvalidTEEType(teeType));
     }
 }

--- a/test/mocks/MockAutomataDcapAttestationFee.sol
+++ b/test/mocks/MockAutomataDcapAttestationFee.sol
@@ -25,9 +25,7 @@ contract MockAutomataDcapAttestationFee {
     error InsufficientFee(uint256 required, uint256 provided);
 
     function verifyAndAttestOnChain(bytes calldata rawQuote) external payable returns (bool, bytes memory) {
-        if (msg.value < baseFee) {
-            revert InsufficientFee(baseFee, msg.value);
-        }
+        require(msg.value >= baseFee, InsufficientFee(baseFee, msg.value));
 
         QuoteResult memory result = quoteResults[rawQuote];
         return (result.success, result.output);


### PR DESCRIPTION
Addresses N-03 on the Q3 2025 OZ audit:

Since Solidity version 0.8.26, custom error support has been added to require statements. Initially, this feature was only available through the IR pipeline. However, Solidity 0.8.27 extended support for this feature to the legacy pipeline as well.

Throughout the codebase, multiple instances where if-revert statements could be replaced with require statements were identified:

For conciseness and gas savings, consider replacing if-revert statements with require statements.