### PR TITLE
add indexes to IFlashtestationRegistry and IBlockBuilderPolicy events

### DIFF
--- a/src/interfaces/IBlockBuilderPolicy.sol
+++ b/src/interfaces/IBlockBuilderPolicy.sol
@@ -31,13 +31,13 @@ interface IBlockBuilderPolicy {
 
     /// @notice Emitted when a workload is added to the policy
     /// @param workloadId The workload identifier
-    event WorkloadAddedToPolicy(bytes32 workloadId);
+    event WorkloadAddedToPolicy(bytes32 indexed workloadId);
     /// @notice Emitted when a workload is removed from the policy
     /// @param workloadId The workload identifier
-    event WorkloadRemovedFromPolicy(bytes32 workloadId);
+    event WorkloadRemovedFromPolicy(bytes32 indexed workloadId);
     /// @notice Emitted when the registry is set in the initializer
     /// @param registry The address of the registry
-    event RegistrySet(address registry);
+    event RegistrySet(address indexed registry);
     /// @notice Emitted when a block builder proof is successfully verified
     /// @param caller The address that called the verification function (TEE address)
     /// @param workloadId The workload identifier of the TEE

--- a/src/interfaces/IFlashtestationRegistry.sol
+++ b/src/interfaces/IFlashtestationRegistry.sol
@@ -25,14 +25,14 @@ interface IFlashtestationRegistry {
     /// @param teeAddress The address of the TEE service
     /// @param rawQuote The raw quote from the TEE device
     /// @param alreadyExists Whether the TEE service is already registered
-    event TEEServiceRegistered(address teeAddress, bytes rawQuote, bool alreadyExists);
+    event TEEServiceRegistered(address indexed teeAddress, bytes rawQuote, bool alreadyExists);
     /// @notice Emitted when a TEE service is invalidated
     /// @param teeAddress The address of the TEE service
-    event TEEServiceInvalidated(address teeAddress);
+    event TEEServiceInvalidated(address indexed teeAddress);
     /// @notice Emitted when a previous signature is invalidated
     /// @param teeAddress The address of the TEE service
     /// @param invalidatedNonce The nonce of the invalidated signature
-    event PreviousSignatureInvalidated(address teeAddress, uint256 invalidatedNonce);
+    event PreviousSignatureInvalidated(address indexed teeAddress, uint256 invalidatedNonce);
 
     // ============ Errors ============
 


### PR DESCRIPTION
This addresses N-05 of the Q3 2025 OZ audit:

Throughout the codebase, several events do not have indexed parameters:

The WorkloadAddedToPolicy event of BlockBuilderPolicy.sol.

The WorkloadRemovedFromPolicy event of BlockBuilderPolicy.sol.

The RegistrySet event of BlockBuilderPolicy.sol.

The BlockBuilderProofVerified event of BlockBuilderPolicy.sol.

The TEEServiceRegistered event of IFlashtestationRegistry.sol.

The TEEServiceInvalidated event of IFlashtestationRegistry.sol.

To improve the ability of off-chain services to search and filter for specific events, consider indexing event parameters.

Note: we didn't add it to the BlockBuilderProofVerified event, in order to keep that event as efficient as possible